### PR TITLE
Python bindings for libjalali

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test_kit/leap
 test_kit/sec_converter
 docs/genpages.sh
 sources/compile
+*.pyc

--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -33,6 +33,8 @@ const int leaps[] = { J_L0, J_L1, J_L2, J_L3, INT_MAX };
 
 const int jalali_month_len[] = { 31, 31, 31, 31, 31, 31, 30, 30, 30, 30,
                                  30, 29 };
+const int accumulated_jalali_month_len[] = { 0, 31, 62, 93, 124, 155, 186,
+                                 216, 246, 276, 306, 336 };
 
 extern char* tzname[2];
 
@@ -177,18 +179,14 @@ int jalali_create_date_from_days(struct jtm* j)
  */
 int jalali_create_days_from_date(struct jtm* j)
 {
-    int p = 0;
-    int i;
+    int p;
     if (j->tm_mon < 0 || j->tm_mon > 11)
         return -1;
 
     if (j->tm_mday < 1 || j->tm_mday > 31)
         return -1;
 
-    for (i=0; i<j->tm_mon; i++) {
-        p+= jalali_month_len[i];
-    }
-
+    p = accumulated_jalali_month_len[j->tm_mon];
     p+= j->tm_mday - 1;
     j->tm_yday = p;
 

--- a/sources/libjalali/jtime.c
+++ b/sources/libjalali/jtime.c
@@ -66,6 +66,7 @@ static char in_buf[MAX_BUF_SIZE] = {0};
 static struct jtm in_jtm;
 
 extern char* tzname[2];
+extern const int jalali_month_len[];
 
 void in_jasctime(const struct jtm* jtm, char* buf)
 {
@@ -226,11 +227,41 @@ struct jtm* jlocaltime(const time_t* timep)
     return &in_jtm;
 }
 
-time_t jmktime(const struct jtm* jtm)
+time_t jmktime(struct jtm* jtm)
 {
     if (!jtm)
         return (time_t) (-1);
     tzset();
+
+    if (jtm->tm_sec >= J_MINUTE_LENGTH_IN_SECONDS) {
+        jtm->tm_min += jtm->tm_sec / J_MINUTE_LENGTH_IN_SECONDS;
+        jtm->tm_sec %= J_MINUTE_LENGTH_IN_SECONDS;
+    }
+    if (jtm->tm_min >= J_HOUR_LENGTH_IN_MINUTES) {
+        jtm->tm_hour += jtm->tm_min / J_HOUR_LENGTH_IN_MINUTES;
+        jtm->tm_min %= J_HOUR_LENGTH_IN_MINUTES;
+    }
+    if (jtm->tm_hour >= J_DAY_LENGTH_IN_HOURS) {
+        jtm->tm_mday += jtm->tm_hour / J_DAY_LENGTH_IN_HOURS;
+        jtm->tm_hour %= J_DAY_LENGTH_IN_HOURS;
+    }
+    int lm;
+    while (jtm->tm_mday>jalali_month_len[jtm->tm_mon%J_YEAR_LENGTH_IN_MONTHS]) {
+        if (jalali_is_jleap(jtm->tm_year+jtm->tm_mon/J_YEAR_LENGTH_IN_MONTHS)) {
+            if (jtm->tm_mon % J_YEAR_LENGTH_IN_MONTHS == 11 && jtm->tm_mday ==30)
+                break;
+            lm = 30;
+        } else {
+            lm = jalali_month_len[jtm->tm_mon % J_YEAR_LENGTH_IN_MONTHS];
+        }
+        jtm->tm_mday -= lm;
+        jtm->tm_mon += 1;
+    }
+    if (jtm->tm_mon >= J_YEAR_LENGTH_IN_MONTHS) {
+        jtm->tm_year += jtm->tm_mon / J_YEAR_LENGTH_IN_MONTHS;
+        jtm->tm_mon %= J_YEAR_LENGTH_IN_MONTHS;
+    }
+    jalali_create_days_from_date(jtm); /* set tm_yday */
 
     int p = jalali_get_diff(jtm);
     time_t t;
@@ -239,6 +270,8 @@ time_t jmktime(const struct jtm* jtm)
         + ((time_t) jtm->tm_min *
            (time_t) J_MINUTE_LENGTH_IN_SECONDS) + (time_t) jtm->tm_sec -
         ((time_t) jtm->tm_gmtoff);
+
+    jalali_get_date(p, jtm); /* set tm_wday, reset tz info, etc .. */
     return t;
 }
 

--- a/sources/libjalali/jtime.c
+++ b/sources/libjalali/jtime.c
@@ -233,36 +233,6 @@ time_t jmktime(struct jtm* jtm)
         return (time_t) (-1);
     tzset();
 
-    if (jtm->tm_sec >= J_MINUTE_LENGTH_IN_SECONDS) {
-        jtm->tm_min += jtm->tm_sec / J_MINUTE_LENGTH_IN_SECONDS;
-        jtm->tm_sec %= J_MINUTE_LENGTH_IN_SECONDS;
-    }
-    if (jtm->tm_min >= J_HOUR_LENGTH_IN_MINUTES) {
-        jtm->tm_hour += jtm->tm_min / J_HOUR_LENGTH_IN_MINUTES;
-        jtm->tm_min %= J_HOUR_LENGTH_IN_MINUTES;
-    }
-    if (jtm->tm_hour >= J_DAY_LENGTH_IN_HOURS) {
-        jtm->tm_mday += jtm->tm_hour / J_DAY_LENGTH_IN_HOURS;
-        jtm->tm_hour %= J_DAY_LENGTH_IN_HOURS;
-    }
-    int lm;
-    while (jtm->tm_mday>jalali_month_len[jtm->tm_mon%J_YEAR_LENGTH_IN_MONTHS]) {
-        if (jalali_is_jleap(jtm->tm_year+jtm->tm_mon/J_YEAR_LENGTH_IN_MONTHS)) {
-            if (jtm->tm_mon % J_YEAR_LENGTH_IN_MONTHS == 11 && jtm->tm_mday ==30)
-                break;
-            lm = 30;
-        } else {
-            lm = jalali_month_len[jtm->tm_mon % J_YEAR_LENGTH_IN_MONTHS];
-        }
-        jtm->tm_mday -= lm;
-        jtm->tm_mon += 1;
-    }
-    if (jtm->tm_mon >= J_YEAR_LENGTH_IN_MONTHS) {
-        jtm->tm_year += jtm->tm_mon / J_YEAR_LENGTH_IN_MONTHS;
-        jtm->tm_mon %= J_YEAR_LENGTH_IN_MONTHS;
-    }
-    jalali_create_days_from_date(jtm); /* set tm_yday */
-
     int p = jalali_get_diff(jtm);
     time_t t;
     t = ((time_t) p * (time_t) J_DAY_LENGTH_IN_SECONDS) +
@@ -270,8 +240,6 @@ time_t jmktime(struct jtm* jtm)
         + ((time_t) jtm->tm_min *
            (time_t) J_MINUTE_LENGTH_IN_SECONDS) + (time_t) jtm->tm_sec -
         ((time_t) jtm->tm_gmtoff);
-
-    jalali_get_date(p, jtm); /* set tm_wday, reset tz info, etc .. */
     return t;
 }
 

--- a/sources/libjalali/jtime.h
+++ b/sources/libjalali/jtime.h
@@ -39,7 +39,7 @@ extern struct jtm* jgmtime(const time_t* timep);
 
 extern struct jtm* jlocaltime(const time_t* timep);
 
-extern time_t jmktime(const struct jtm* jtm);
+extern time_t jmktime(struct jtm* jtm);
 
 extern size_t jstrftime(char* s, size_t max, const char* format,
             const struct jtm* jtm);

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -12,8 +12,13 @@
     using libjalali tools.
     """
 
-
+import sys
+import ctypes.util
 from ctypes import cdll
-_libj = cdll.LoadLibrary('libjalali.so')
 
-import pyjalali.jtime, pyjalali.jstr, pyjalali.jalali, pyjalali.datetime
+if sys.platform.startswith('win'):
+    libname = 'libjalali.dll'
+else:
+    libname = ctypes.util.find_library('jalali')
+_libj = cdll.LoadLibrary(libname)
+del cdll, ctypes, sys, libname

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -4,12 +4,13 @@
 
     Python bindings for libjalali.
 
-    Low level API could be accessed through :data:`~pyjalali.jstr` and
-    :data:`~pyjalali.ctime` modules.  Core libjalali data structures resides
-    in `types` module.
+    Low level API could be accessed through :data:`jstr`, :data:`jtime` and
+    :data:`jalali` modules.  Core libjalali data structures resides in
+    :data:`types` module.
     
-    An implementation of standard datetime module provided in module datetime
-    using libjalali tools.
+    An implementation of standard :data:`datetime`'s :class:`date` and
+    :class:`datetime` provided in module :data:`~pyjalali.datetime` using
+    libjalali tools.
 """
 
 import sys

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -10,7 +10,7 @@
     
     An implementation of standard datetime module provided in module datetime
     using libjalali tools.
-    """
+"""
 
 import sys
 import ctypes.util

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -5,8 +5,8 @@
     Python bindings for libjalali.
 
     Low level API could be accessed through :data:`~pyjalali.jstr` and
-    :data:`~pyjalali.ctime` modules.  core libjalali data structures resides
-    in `types
+    :data:`~pyjalali.ctime` modules.  Core libjalali data structures resides
+    in `types` module.
     
     An implementation of standard datetime module provided in module datetime
     using libjalali tools.

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -14,4 +14,4 @@
 from ctypes import cdll
 _libj = cdll.LoadLibrary('libjalali.so')
 
-import pyjalali.jtime, pyjalali.jstr
+import pyjalali.jtime, pyjalali.jstr, pyjalali.jalali

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -16,6 +16,9 @@ import sys
 import ctypes.util
 from ctypes import cdll
 
+# hardcoded libjalali version, binding revision
+__version__ = (0, 5, 0, 1)
+
 if sys.platform.startswith('win'):
     libname = 'libjalali.dll'
 else:

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -1,0 +1,17 @@
+"""
+    pyjalali
+    ~~~~~~~~
+
+    Python bindings for libjalali.
+
+    Low level API could be accessed through :data:`~pyjalali.jstr` and
+    :data:`~pyjalali.ctime` modules.
+
+    libjalali data structures resides in `types`
+"""
+
+
+from ctypes import cdll
+_libj = cdll.LoadLibrary('libjalali.so')
+
+import pyjalali.jtime, pyjalali.jstr

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -5,13 +5,15 @@
     Python bindings for libjalali.
 
     Low level API could be accessed through :data:`~pyjalali.jstr` and
-    :data:`~pyjalali.ctime` modules.
-
-    libjalali data structures resides in `types`
-"""
+    :data:`~pyjalali.ctime` modules.  core libjalali data structures resides
+    in `types
+    
+    An implementation of standard datetime module provided in module datetime
+    using libjalali tools.
+    """
 
 
 from ctypes import cdll
 _libj = cdll.LoadLibrary('libjalali.so')
 
-import pyjalali.jtime, pyjalali.jstr, pyjalali.jalali
+import pyjalali.jtime, pyjalali.jstr, pyjalali.jalali, pyjalali.datetime

--- a/sources/pyjalali/datetime.py
+++ b/sources/pyjalali/datetime.py
@@ -5,7 +5,7 @@
     High level API for libjalali.  Intended to be similar to standard
     data:`datetime` module.
 
-    .. Note ::  
+    .. Note ::
         * There is no `iso_calendar` or `to_ordinal` or `fromordinal` method
           here.  Implementing them is easy, just forward to
           :attr:`~pyjalali.datetime.gregorian` but those methods are not
@@ -21,45 +21,140 @@ from pyjalali.jalali import jalali_update, jalali_create_days_from_date
 from pyjalali.jtime import jctime_r, jgmtime_r, jlocaltime_r, jmktime
 from pyjalali.jstr import jstrftime, jstrptime
 from pyjalali.types import struct_jtm, jtm_to_struct_time
-from pyjalali.helpers import normalize_jtm, get_yday
+from pyjalali.helpers import normalize_jtm
+
+
+__all__ = ('date', 'datetime', 'jdatetime_from_dt', 'dt_from_jdatetime',
+           'now', 'utcnow', 'jdatetime_from_ts')
+
 
 class date(object):
     __have_yday_wday = False
+
     def __init__(self, year, month, day):
         if not 1 <= month <= 12:
             raise ValueError('month value out of range [1, 12]')
-        self.jtm = struct_jtm()
-        self.jtm.tm_year = year
-        self.jtm.tm_mon = month - 1
-        self.jtm.tm_mday = day
+        self.__jtm = struct_jtm()
+        self.__jtm.tm_year = year
+        self.__jtm.tm_mon = month - 1
+        self.__jtm.tm_mday = day
+
+    def __add__(self, delta):
+        if isinstance(delta, _std_dt_mod.timedelta):
+            njtm = self.__jtm.copy()
+            njtm.tm_mday += delta.days
+            normalize_jtm(njtm)
+            return date(njtm.tm_year, njtm.tm_mon + 1, njtm.tm_mday)
+        raise TypeError('Unsupported operand type for +: %s and %s' %
+                        (self.__class__.__name__, delta.__class__.__name__))
+
+    def __lt__(self, jdate):
+        if isinstance(jdate, date):
+            return (self.year < jdate.year or self.month < jdate.month or
+                    self.day < jdate.day)
+        raise TypeError('Unsupported operand type for =: %s and %s' %
+                        (self.__class__.__name__, jdate.__class__.__name__))
+
+    def __sub__(self, delta_or_date):
+        if isinstance(delta_or_date, _std_dt_mod.timedelta):
+            delta = delta_or_date
+            njtm = self.__jtm.copy()
+            njtm.tm_mday -= delta.days
+            normalize_jtm(njtm)
+            return date(njtm.tm_year, njtm.tm_mon + 1, njtm.tm_mday)
+        if isinstance(delta_or_date, date):
+            jd = delta_or_date
+            onjtm = jd.jtm.copy()
+            self._compute_yday_wday_if_necessary()
+            jalali_create_days_from_date(onjtm)
+            dx = self.__jtm.tm_yday - onjtm.tm_yday
+            return _std_dt_mod.timedelta(days=dx)
+        raise TypeError('Unsupported operand type for -: %s and %s' %
+                        (self.__class__.__name__,
+                         delta_or_date.__class__.__name__))
+
+    def __repr__(self):
+        return '%s.%s(%d, %d, %d)' % (self.__module__,
+                                      self.__class__.__name__,
+                                      self.year,
+                                      self.month,
+                                      self.day)
+
+    def __str__(self):
+        return self.isoformat()
+
+    def __format__(self, format):
+        return self.strftime(format)
+
+    def _compute_yday_wday_if_necessary(self):
+        if not self.__have_yday_wday:
+            njtm = self.__jtm.copy()
+            jalali_update(njtm)
+            self.__jtm.tm_wday = njtm.tm_wday
+            self.__jtm.tm_yday = njtm.tm_yday
+            self.__have_yday_wday = True
+
+    @property
+    def jtm(self):
+        return self.__jtm
 
     @property
     def year(self):
-        return self.jtm.tm_year
+        return self.__jtm.tm_year
 
     @property
     def month(self):
-        return self.jtm.tm_mon + 1
+        return self.__jtm.tm_mon + 1
+
+    def ctime(self):
+        njtm = self.__jtm.copy()
+        jalali_update(njtm)
+        return jctime_r(jmktime(njtm))
 
     @property
     def day(self):
-        return self.jtm.tm_mday
+        return self.__jtm.tm_mday
+
+    def replace(self, **kw):
+        d = dict(year=self.year, month=self.month, day=self.day)
+        d.update(**kw)
+        return date(**d)
 
     @classmethod
     def today(self):
-        return date.fromtimestamp(int(_timestamp()))
+        return date.fromtimestamp(_timestamp())
+
+    def timetuple(self):
+        # TODO: chaneg after jmktime fix
+        njtm = self.__jtm.copy()
+        jalali_update(njtm)
+        njtm.tm_isdst = -1
+        return jtm_to_struct_time(njtm)
 
     @classmethod
     def fromtimestamp(self, ts):
-        jmt = jlocaltime_r(ts)
-        return date(jmt.tm_year, jtm.tm_mon + 1, jtm.tm_mday)
+        jtm = jlocaltime_r(int(ts))
+        return date(jtm.tm_year, jtm.tm_mon + 1, jtm.tm_mday)
 
     def isoformat(self):
         return self.strftime('%Y-%m-%d')
 
+    def isoweekday(self):
+        return self.weekday() + 1
+
+    def strftime(self, format):
+        self._compute_yday_wday_if_necessary()
+        return jstrftime(format, self.__jtm)
+
+    def weekday(self):
+        self._compute_yday_wday_if_necessary()
+        return self.__jtm.tm_wday
+
 
 date.min = date(1, 1, 1)
 date.max = date(9999, 12, 29)
+date.resolution = _std_dt_mod.timedelta(days=1)
+
 
 class datetime():
     """Differences with :class:`datetime.datetime`:
@@ -69,9 +164,7 @@ class datetime():
           formatting that differs with standard formatting.
     """
 
-    jtm = None
     tzinfo = None
-    __have_yday_wday = False
     __hash_val = None
 
     def __init__(self, year, month, day, hour=None, minute=None, second=None,
@@ -79,43 +172,45 @@ class datetime():
         if not isinstance(microsecond, int):
             raise TypeError
         self.__date = date(year, month, day)
-        self.jtm = self.__date.jtm
+        self.__jtm = self.__date.jtm
         if hour is not None:
-            self.jtm.tm_hour = hour
+            self.__jtm.tm_hour = hour
         if minute is not None:
-            self.jtm.tm_min = minute
+            self.__jtm.tm_min = minute
         if second is not None:
-            self.jtm.tm_sec = second
+            self.__jtm.tm_sec = second
         self.microsecond = microsecond
         self.tzinfo = tzinfo
 
     def __add__(self, delta):
         if isinstance(delta, _std_dt_mod.timedelta):
-            njtm = self.jtm.copy()
+            njtm = self.__jtm.copy()
             njtm.tm_sec += delta.seconds
             njtm.tm_mday += delta.days
-            ms = normalize_jtm(njtm, self.microsecond + delta.microseconds) 
+            ms = normalize_jtm(njtm, self.microsecond + delta.microseconds)
             return jdatetime_from_jtm(njtm, ms, self.tzinfo)
-        raise TypeError('Unsupported operand type for +: %s and %s' % \
+        raise TypeError('Unsupported operand type for +: %s and %s' %
                         (self.__class__.__name__, delta.__class__.__name__))
 
     def __eq__(self, jdt):
         if isinstance(jdt, datetime):
             if (jdt.tzinfo is None) != (self.tzinfo is None):
-                raise TypeError("can't compare offset-naive and offset-aware"\
+                raise TypeError("can't compare offset-naive and offset-aware"
                                 "datetime")
             if jdt.tzinfo != self.tzinfo:
                 return (self.replace(tzinfo=None) - self.utcoffset()) == \
                        (jdt.replace(tzinfo=None) - jdt.utcoffset())
-            return self.year == jdt.year and self.month == jdt.month and \
-                   self.day == jdt.day and self.hour == jdt.hour and \
-                   self.minute == jdt.minute and self.second == jdt.second \
-                   and self.microsecond == jdt.microsecond
-        raise TypeError('Unsupported operand type for ==: %s and %s' % \
+            return (self.year == jdt.year and self.month == jdt.month and
+                    self.day == jdt.day and self.hour == jdt.hour and
+                    self.minute == jdt.minute and self.second == jdt.second
+                    and self.microsecond == jdt.microsecond)
+        raise TypeError('Unsupported operand type for ==: %s and %s' %
                         (self.__class__.__name__, jdt.__class__.__name__))
 
     def __hash__(self):
         # XXX:
+        # tzinfo shoudn't count, two date with different zone's should produce
+        # same hash but if one is aware and one is naive it should be different
         if self.__hash_val is None:
             self.__hash_val = self.year
             self.__hash_val = self.__hash_val * 100 + self.month
@@ -134,7 +229,7 @@ class datetime():
         if isinstance(dt, _std_dt_mod.datetime):
             # It might seem stupid but pytz needs this anyway
             return self.gregorian < dt
-        raise TypeError('Unsupported operand type for <: %s and %s' % \
+        raise TypeError('Unsupported operand type for <: %s and %s' %
                         (self.__class__.__name__, dt.__class__.__name__))
 
     def __repr__(self):
@@ -158,44 +253,36 @@ class datetime():
     def __sub__(self, delta_or_jdt):
         if isinstance(delta_or_jdt, _std_dt_mod.timedelta):
             delta = delta_or_jdt
-            njtm = self.jtm.copy()
+            njtm = self.__jtm.copy()
             njtm.tm_sec -= delta.seconds
             njtm.tm_mday -= delta.days
             ms = normalize_jtm(njtm, self.microsecond - delta.microseconds)
             return jdatetime_from_jtm(njtm, ms, self.tzinfo)
         if isinstance(delta_or_jdt, _std_dt_mod.datetime):
-            raise TypeError("It doesn't make sense subtract Gregorian date " \
+            raise TypeError("It doesn't make sense subtract Gregorian date "
                             "from Jalali date")
         if isinstance(delta_or_jdt, datetime):
             jdt = delta_or_jdt
             if (self.tzinfo is None) != (jdt.tzinfo is None):
-                raise TypeError("can't subtract offset-naive and offset-aware"\
+                raise TypeError("can't subtract offset-naive and offset-aware"
                                 "datetimes")
             if self.tzinfo != jdt.tzinfo:
                 return (self.replace(tzinfo=None) - self.utcoffset()) - \
                        (jdt.replace(tzinfo=None) - jdt.utcoffset())
-            if not self.__have_yday_wday:
-                self._compute_wday_yday()
+            self.__date._compute_yday_wday_if_necessary()
             onjtm = jdt.jtm.copy()
             jalali_create_days_from_date(onjtm)
-            dx = _std_dt_mod.timedelta(days = self.jtm.tm_yday-onjtm.tm_yday,
-                                       hours = self.hour - jdt.hour,
-                                       minutes = self.minute - jdt.minute,
-                                       seconds = self.second - jdt.second,
-                                       microseconds = self.microsecond -
-                                                      jdt.microsecond)
+            dx = _std_dt_mod.timedelta(days=self.__jtm.tm_yday-onjtm.tm_yday,
+                                       hours=self.hour - jdt.hour,
+                                       minutes=self.minute - jdt.minute,
+                                       seconds=self.second - jdt.second,
+                                       microseconds=(self.microsecond -
+                                                     jdt.microsecond))
             return dx
-        raise TypeError('Unsupported operand type for -: %s and %s' % \
-                        (self.__class__.__name__, delta_or_jdt.__class__.__name__))
+        raise TypeError('Unsupported operand type for -: %s and %s' %
+                        (self.__class__.__name__,
+                         delta_or_jdt.__class__.__name__))
 
-    def _compute_wday_yday(self):
-        # DANGER: i'm not *very* sure about jalali_update here
-        njtm = self.jtm.copy()
-        jalali_update(njtm)
-        self.jtm.tm_wday = njtm.tm_wday
-        self.jtm.tm_yday = njtm.tm_yday
-        self.__have_yday_wday = True
-    
     def astimezone(self, tz):
         """
         >>> from pytz import timezone
@@ -210,14 +297,13 @@ class datetime():
         utc = (self - self.utcoffset()).replace(tzinfo=None)
         return tz.fromutc(utc)
 
-
     def dst(self):
         if self.tzinfo is None:
             return
         rv = self.tzinfo.dst(self)
         if rv is None or isinstance(rv, _std_dt_mod.timedelta):
             return rv
-        raise TypeError("tzinfo.dst() must return None or a timedelta, not " \
+        raise TypeError("tzinfo.dst() must return None or a timedelta, not "
                         "'%s'" % rv.__class__.__name__)
 
     @property
@@ -228,47 +314,52 @@ class datetime():
 
     @property
     def year(self):
-        return self.jtm.tm_year
+        return self.__jtm.tm_year
 
     @property
     def month(self):
-        return self.jtm.tm_mon + 1
+        return self.__jtm.tm_mon + 1
 
     @property
     def day(self):
-        return self.jtm.tm_mday
+        return self.__jtm.tm_mday
 
     @property
     def hour(self):
-        return self.jtm.tm_hour
+        return self.__jtm.tm_hour
 
     @property
     def minute(self):
-        return self.jtm.tm_min
+        return self.__jtm.tm_min
 
     @property
     def second(self):
-        return self.jtm.tm_sec
+        return self.__jtm.tm_sec
 
     @classmethod
     def combine(self, date, time):
-        return datetime(self.year, self.month, self.day, self.hour,
-               self.minute, self.second, self.microsecond, self.tzinfo)
+        return datetime(date.year, date.month, date.day, time.hour,
+                        time.minute, time.second, time.microsecond,
+                        time.tzinfo)
 
     def ctime(self):
         # TODO:
         # this should be enough if jmktime fixed:
-        # return jctime_r(jmktime(self.jtm))
-        njtm = self.jtm.copy()
+        # return jctime_r(jmktime(self.__jtm))
+        njtm = self.__jtm.copy()
         jalali_update(njtm)
         return jctime_r(jmktime(njtm))
 
     def date(self):
-        return self.__date
+        return self.__date.replace()
 
     @classmethod
     def fromtimestamp(self, ts, tz=None):
         return jdatetime_from_ts(ts, True, tz)
+
+    @property
+    def jtm(self):
+        return self.__jtm
 
     def isoformat(self, sep='T'):
         format = '%Y-%m-%d'+sep+'%H:%M:%S'
@@ -283,11 +374,15 @@ class datetime():
             format += '%s%s' % (sign, str(utcoff).rsplit(':', 1)[0])
         return self.strftime(format)
 
+    def isoweekday(self):
+        return self.__date.isoweekday()
+
     @classmethod
     def now(self, tz=None):
         return now(tz)
 
     def replace(self, **kw):
+        # TODO: make it like std, with positional args
         d = dict(year=self.year, month=self.month, day=self.day,
                  hour=self.hour, minute=self.minute, second=self.second,
                  microsecond=self.microsecond, tzinfo=self.tzinfo)
@@ -305,19 +400,18 @@ class datetime():
         :class:`datetime.datetime` since it should store more information and
         change method signatures.
 
-        So consider returned values for every switch depended to timezone
-        information, like '%s' is wrong.
+        So consider returned values for every switch depending on timezone
+        information, like '%s', as wrong.
         """
-        if not self.__have_yday_wday:
-            self._compute_wday_yday()        
-        return jstrftime(format, self.jtm)
-    
+        self.__date._compute_yday_wday_if_necessary()
+        return jstrftime(format, self.__jtm)
+
     @classmethod
     def strptime(self, date_str, format):
         return jdatetime_from_jtm(jstrptime(format, date_str))
 
     def timetuple(self):
-        njtm = self.jtm.copy()
+        njtm = self.__jtm.copy()
         jalali_update(njtm)
         if self.dst() is None:
             njtm.tm_isdst = -1
@@ -337,11 +431,12 @@ class datetime():
         return jtm_to_struct_time(njtm)
 
     def time(self):
-        return _std_dt_mod.time(self.hour, self.minute, self.second)
-    
+        return _std_dt_mod.time(self.hour, self.minute, self.second,
+                                self.microsecond)
+
     def timetz(self):
         return _std_dt_mod.time(self.hour, self.minute, self.second,
-                                self.tzinfo)
+                                self.microsecond, self.tzinfo)
 
     @classmethod
     def today(self):
@@ -353,7 +448,7 @@ class datetime():
         rv = self.tzinfo.tzname(self)
         if rv is None or isinstance(rv, str):
             return rv
-        raise TypeError("tzinfo.tzname() must return None or a str, not " \
+        raise TypeError("tzinfo.tzname() must return None or a str, not "
                         "'%s'" % self.__class__.__name__)
 
     def utcoffset(self):
@@ -381,7 +476,7 @@ class datetime():
         rv = self.tzinfo.utcoffset(self)
         if rv is None or isinstance(rv, _std_dt_mod.timedelta):
             return rv
-        raise TypeError("tzinfo.utcoffset() must return None or a timedelta, "\
+        raise TypeError("tzinfo.utcoffset() must return None or a timedelta, "
                         "not '%s'" % rv.__class__.__name__)
 
     @classmethod
@@ -392,15 +487,14 @@ class datetime():
     def utcnow(self):
         return utcnow()
 
+    def weekday(self):
+        return self.__date.weekday()
 
-datetime.min = datetime(1,1,1)
+
+datetime.min = datetime(1, 1, 1)
 #XXX: not sure, ask ashkan
 datetime.max = datetime(9999, 12, 29, 23, 59, 59)
 datetime.resolution = _std_dt_mod.timedelta(seconds=1)
-
-date.__format__ = datetime.__format__ = lambda s, f: s.strftime(f)
-date.weekday = datetime.weekday = lambda self: self.jtm.tm_wday
-date.isoweekday = datetime.isoweekday = lambda self: self.jtm.tm_wday + 1
 
 
 def now(timezone=None):
@@ -436,10 +530,9 @@ def jdatetime_from_dt(dt):
     """
     if not isinstance(dt, _std_dt_mod.datetime):
         raise TypeError('Expected %s instance' % _std_dt_mod.datetime)
-    ndt = dt.replace(hour=12, minute=0, second=0) # no dst changes here
-    ts = mktime(ndt.timetuple())
-    return datetime.fromtimestamp(ts).replace(hour=dt.hour, minute=dt.minute,
-           second=dt.second, microsecond=dt.microsecond)
+    gdate, time = dt.date(), dt.timetz()
+    jdate = date.fromtimestamp(mktime(gdate.timetuple()))
+    return datetime.combine(jdate, time)
 
 
 def dt_from_jdatetime(jdt):
@@ -451,16 +544,14 @@ def dt_from_jdatetime(jdt):
     """
     if not isinstance(jdt, datetime):
         raise TypeError
-    njtm = jdt.jtm.copy()
     # to stop dst changes from bugging conversion, just convert date
-    njtm.tm_hour = njtm.tm_min = njtm.tm_sec = 12
-    #TODO: change after jmktime fix
-    jalali_update(njtm) # pragma: jmktime needs yday
-    return _std_dt_mod.datetime.fromtimestamp(jmktime(njtm)) \
-            .replace(hour=jdt.hour, minute=jdt.minute, second=jdt.second,
-                     microsecond=jdt.microsecond, tzinfo=jdt.tzinfo)
+    jdate, time = jdt.date(), jdt.timetz()
+    njtm = jdate.jtm.copy()
+    jalali_update(njtm)  # pragma: jmktime needs yday TODO: remove
+    gdate = _std_dt_mod.date.fromtimestamp(jmktime(njtm))
+    return _std_dt_mod.datetime.combine(gdate, time)
 
 
 def jdatetime_from_jtm(jtm, microsecond=0, tz=None):
-    jdt = datetime(*jtm_to_struct_time(jtm)[:6], microsecond=microsecond, tzinfo=tz)
-    return jdt
+    return datetime(*jtm_to_struct_time(jtm)[:6], microsecond=microsecond,
+                    tzinfo=tz)

--- a/sources/pyjalali/datetime.py
+++ b/sources/pyjalali/datetime.py
@@ -61,7 +61,7 @@ class date(object):
 
     def __hash__(self):
         if self.__hash_val is None:
-            self.__hash_val = hash(self.year, self.month, self.day, 101)
+            self.__hash_val = hash((self.year, self.month, self.day, 101))
         return self.__hash_val
 
     def __lt__(self, jdate):

--- a/sources/pyjalali/datetime.py
+++ b/sources/pyjalali/datetime.py
@@ -67,8 +67,15 @@ class date(object):
 
     def __lt__(self, jdate):
         if isinstance(jdate, date):
-            return (self.year < jdate.year or self.month < jdate.month or
-                    self.day < jdate.day)
+            if self.year < jdate.year:
+                return True
+            elif self.year != jdate.year:
+                return False
+            if self.month < jdate.month:
+                return True
+            elif self.month != jdate.month:
+                return False
+            return True if self.day < jdate.day else False
         raise TypeError('Unsupported operand type for <: %s and %s' %
                         (self.__class__.__name__, jdate.__class__.__name__))
 
@@ -248,10 +255,31 @@ class datetime(object):
             d1 = self
             d2 = dt
             if (d1.tzinfo or d2.tzinfo) is None:
-                return (d1.year < d2.year or d1.month < d2.month or d1.day <
-                        d2.day or d1.hour < d2.hour or d1.minute < d2.minute or
-                        d1.second < d2.second or d1.microsecond <
-                        d2.microsecond)
+                if d1.year < d2.year:
+                    return True
+                if d1.year != d2.year:
+                    return False
+                if d1.month < d2.month:
+                    return True
+                if d1.month != d2.month:
+                    return False
+                if d1.day < d2.day:
+                    return True
+                elif d1.day != d2.day:
+                    return False
+                if d1.hour < d2.hour:
+                    return True
+                elif d1.hour != d2.hour:
+                    return False
+                if d1.minute < d2.minute:
+                    return True
+                elif d1.minute != d2.minute:
+                    return False
+                if d1.second < d2.second:
+                    return True
+                elif d1.second != d2.second:
+                    return False
+                return True if d1.microsecond < d2.microsecond else False
             if not (d1.tzinfo and d2.tzinfo):
                 raise TypeError("can't compare offset-naive and offset-aware"
                                 "datetimes")
@@ -592,6 +620,8 @@ def jalali_from_gregorian(date_or_datetime):
                         (_std_dt_mod.datetime.__name__,
                          _std_dt_mod.date.__name__,
                          date_or_datetime.__class__.__name__))
+    if gdate < _std_dt_mod.date(1970, 1, 1):
+        raise ValueError("xxxxx Can't convert dates before Epoch")
     jdate = date.fromtimestamp(mktime(gdate.timetuple()))
     if time is None:
         return jdate
@@ -618,6 +648,8 @@ def gregorian_from_jalali(date_or_datetime):
         raise TypeError('Expected Jalali %s or %s instance, not %s' %
                         (datetime.__name__, date.__name__,
                          date_or_datetime.__class__.__name__))
+    if jdate < date(1348, 10, 11):
+        raise ValueError("Can't convert dates before Epoch")
     # to stop dst changes from bugging conversion, just convert date
     njtm = jdate.jtm.copy()
     jalali_update(njtm)  # pragma: jmktime needs yday TODO: remove

--- a/sources/pyjalali/datetime.py
+++ b/sources/pyjalali/datetime.py
@@ -1,0 +1,466 @@
+"""
+    pyjalali.datetime
+    ~~~~~~~~~~~~~~~~~
+
+    High level API for libjalali.  Intended to be similar to standard
+    data:`datetime` module.
+
+    .. Note ::  
+        * There is no `iso_calendar` or `to_ordinal` or `fromordinal` method
+          here.  Implementing them is easy, just forward to
+          :attr:`~pyjalali.datetime.gregorian` but those methods are not
+          related to Jalali really
+
+"""
+
+from __future__ import absolute_import
+import datetime as _std_dt_mod
+from time import time as _timestamp, mktime, strftime
+
+from pyjalali.jalali import jalali_update, jalali_create_days_from_date
+from pyjalali.jtime import jctime_r, jgmtime_r, jlocaltime_r, jmktime
+from pyjalali.jstr import jstrftime, jstrptime
+from pyjalali.types import struct_jtm, jtm_to_struct_time
+from pyjalali.helpers import normalize_jtm, get_yday
+
+class date(object):
+    __have_yday_wday = False
+    def __init__(self, year, month, day):
+        if not 1 <= month <= 12:
+            raise ValueError('month value out of range [1, 12]')
+        self.jtm = struct_jtm()
+        self.jtm.tm_year = year
+        self.jtm.tm_mon = month - 1
+        self.jtm.tm_mday = day
+
+    @property
+    def year(self):
+        return self.jtm.tm_year
+
+    @property
+    def month(self):
+        return self.jtm.tm_mon + 1
+
+    @property
+    def day(self):
+        return self.jtm.tm_mday
+
+    @classmethod
+    def today(self):
+        return date.fromtimestamp(int(_timestamp()))
+
+    @classmethod
+    def fromtimestamp(self, ts):
+        jmt = jlocaltime_r(ts)
+        return date(jmt.tm_year, jtm.tm_mon + 1, jtm.tm_mday)
+
+    def isoformat(self):
+        return self.strftime('%Y-%m-%d')
+
+
+date.min = date(1, 1, 1)
+date.max = date(9999, 12, 29)
+
+class datetime():
+    """Differences with :class:`datetime.datetime`:
+        * Microsecond could not specified here.
+
+        * :attr:`strftime` and :attr:`strptime` accept customized libjalali
+          formatting that differs with standard formatting.
+    """
+
+    jtm = None
+    tzinfo = None
+    __have_yday_wday = False
+    __hash_val = None
+
+    def __init__(self, year, month, day, hour=None, minute=None, second=None,
+                 microsecond=0, tzinfo=None):
+        if not isinstance(microsecond, int):
+            raise TypeError
+        self.__date = date(year, month, day)
+        self.jtm = self.__date.jtm
+        if hour is not None:
+            self.jtm.tm_hour = hour
+        if minute is not None:
+            self.jtm.tm_min = minute
+        if second is not None:
+            self.jtm.tm_sec = second
+        self.microsecond = microsecond
+        self.tzinfo = tzinfo
+
+    def __add__(self, delta):
+        if isinstance(delta, _std_dt_mod.timedelta):
+            njtm = self.jtm.copy()
+            njtm.tm_sec += delta.seconds
+            njtm.tm_mday += delta.days
+            ms = normalize_jtm(njtm, self.microsecond + delta.microseconds) 
+            return jdatetime_from_jtm(njtm, ms, self.tzinfo)
+        raise TypeError('Unsupported operand type for +: %s and %s' % \
+                        (self.__class__.__name__, delta.__class__.__name__))
+
+    def __eq__(self, jdt):
+        if isinstance(jdt, datetime):
+            if (jdt.tzinfo is None) != (self.tzinfo is None):
+                raise TypeError("can't compare offset-naive and offset-aware"\
+                                "datetime")
+            if jdt.tzinfo != self.tzinfo:
+                return (self.replace(tzinfo=None) - self.utcoffset()) == \
+                       (jdt.replace(tzinfo=None) - jdt.utcoffset())
+            return self.year == jdt.year and self.month == jdt.month and \
+                   self.day == jdt.day and self.hour == jdt.hour and \
+                   self.minute == jdt.minute and self.second == jdt.second \
+                   and self.microsecond == jdt.microsecond
+        raise TypeError('Unsupported operand type for ==: %s and %s' % \
+                        (self.__class__.__name__, jdt.__class__.__name__))
+
+    def __hash__(self):
+        # XXX:
+        if self.__hash_val is None:
+            self.__hash_val = self.year
+            self.__hash_val = self.__hash_val * 100 + self.month
+            self.__hash_val = self.__hash_val * 100 + self.day
+            self.__hash_val = self.__hash_val * 100 + self.hour
+            self.__hash_val = self.__hash_val * 100 + self.minute
+            self.__hash_val = self.__hash_val * 100 + self.day
+            self.__hash_val = self.__hash_val * 1000000 + self.second
+            if self.tzinfo is not None:
+                self.__hash_val += hash(self.tzinfo)
+        return self.__hash_val
+
+    def __lt__(self, dt):
+        if isinstance(dt, datetime):
+            return (self - dt).total_seconds() < 0
+        if isinstance(dt, _std_dt_mod.datetime):
+            # It might seem stupid but pytz needs this anyway
+            return self.gregorian < dt
+        raise TypeError('Unsupported operand type for <: %s and %s' % \
+                        (self.__class__.__name__, dt.__class__.__name__))
+
+    def __repr__(self):
+        fmt = '%s.%s(%s, %s, %s, %s, %s, %s, %s%%s' % \
+              (self.__module__,
+               self.__class__.__name__,
+               repr(self.year),
+               repr(self.month),
+               repr(self.day),
+               repr(self.hour),
+               repr(self.minute),
+               repr(self.second),
+               repr(self.microsecond))
+        if self.tzinfo is not None:
+            return fmt % ', tzinfo=%s)' % repr(self.tzinfo)
+        return fmt % ')'
+
+    def __str__(self):
+        return self.isoformat(' ')
+
+    def __sub__(self, delta_or_jdt):
+        if isinstance(delta_or_jdt, _std_dt_mod.timedelta):
+            delta = delta_or_jdt
+            njtm = self.jtm.copy()
+            njtm.tm_sec -= delta.seconds
+            njtm.tm_mday -= delta.days
+            ms = normalize_jtm(njtm, self.microsecond - delta.microseconds)
+            return jdatetime_from_jtm(njtm, ms, self.tzinfo)
+        if isinstance(delta_or_jdt, _std_dt_mod.datetime):
+            raise TypeError("It doesn't make sense subtract Gregorian date " \
+                            "from Jalali date")
+        if isinstance(delta_or_jdt, datetime):
+            jdt = delta_or_jdt
+            if (self.tzinfo is None) != (jdt.tzinfo is None):
+                raise TypeError("can't subtract offset-naive and offset-aware"\
+                                "datetimes")
+            if self.tzinfo != jdt.tzinfo:
+                return (self.replace(tzinfo=None) - self.utcoffset()) - \
+                       (jdt.replace(tzinfo=None) - jdt.utcoffset())
+            if not self.__have_yday_wday:
+                self._compute_wday_yday()
+            onjtm = jdt.jtm.copy()
+            jalali_create_days_from_date(onjtm)
+            dx = _std_dt_mod.timedelta(days = self.jtm.tm_yday-onjtm.tm_yday,
+                                       hours = self.hour - jdt.hour,
+                                       minutes = self.minute - jdt.minute,
+                                       seconds = self.second - jdt.second,
+                                       microseconds = self.microsecond -
+                                                      jdt.microsecond)
+            return dx
+        raise TypeError('Unsupported operand type for -: %s and %s' % \
+                        (self.__class__.__name__, delta_or_jdt.__class__.__name__))
+
+    def _compute_wday_yday(self):
+        # DANGER: i'm not *very* sure about jalali_update here
+        njtm = self.jtm.copy()
+        jalali_update(njtm)
+        self.jtm.tm_wday = njtm.tm_wday
+        self.jtm.tm_yday = njtm.tm_yday
+        self.__have_yday_wday = True
+    
+    def astimezone(self, tz):
+        """
+        >>> from pytz import timezone
+        >>> d1 = datetime.now(timezone('Asia/Tehran'))
+        >>> d2 = d1.astimezone(timezone('Asia/Dubai'))
+        >>> d1 == d2, d1 - d2
+        (True, datetime.timedelta(0))
+        """
+        if self.tzinfo is None:
+            raise ValueError('astimezone() cannot be applied to naive-offset '
+                             'datetime')
+        utc = (self - self.utcoffset()).replace(tzinfo=None)
+        return tz.fromutc(utc)
+
+
+    def dst(self):
+        if self.tzinfo is None:
+            return
+        rv = self.tzinfo.dst(self)
+        if rv is None or isinstance(rv, _std_dt_mod.timedelta):
+            return rv
+        raise TypeError("tzinfo.dst() must return None or a timedelta, not " \
+                        "'%s'" % rv.__class__.__name__)
+
+    @property
+    def gregorian(self):
+        if getattr(self, '__gregorian', None) is None:
+            self.__gregorian = dt_from_jdatetime(self)
+        return self.__gregorian
+
+    @property
+    def year(self):
+        return self.jtm.tm_year
+
+    @property
+    def month(self):
+        return self.jtm.tm_mon + 1
+
+    @property
+    def day(self):
+        return self.jtm.tm_mday
+
+    @property
+    def hour(self):
+        return self.jtm.tm_hour
+
+    @property
+    def minute(self):
+        return self.jtm.tm_min
+
+    @property
+    def second(self):
+        return self.jtm.tm_sec
+
+    @classmethod
+    def combine(self, date, time):
+        return datetime(self.year, self.month, self.day, self.hour,
+               self.minute, self.second, self.microsecond, self.tzinfo)
+
+    def ctime(self):
+        # TODO:
+        # this should be enough if jmktime fixed:
+        # return jctime_r(jmktime(self.jtm))
+        njtm = self.jtm.copy()
+        jalali_update(njtm)
+        return jctime_r(jmktime(njtm))
+
+    def date(self):
+        return self.__date
+
+    @classmethod
+    def fromtimestamp(self, ts, tz=None):
+        return jdatetime_from_ts(ts, True, tz)
+
+    def isoformat(self, sep='T'):
+        format = '%Y-%m-%d'+sep+'%H:%M:%S'
+        if self.microsecond != 0:
+            format += '.%d' % self.microsecond
+        utcoff = self.utcoffset()
+        if utcoff is not None:
+            if utcoff.total_seconds() >= 0:
+                sign = '+'
+            else:
+                sign = '-'
+            format += '%s%s' % (sign, str(utcoff).rsplit(':', 1)[0])
+        return self.strftime(format)
+
+    @classmethod
+    def now(self, tz=None):
+        return now(tz)
+
+    def replace(self, **kw):
+        d = dict(year=self.year, month=self.month, day=self.day,
+                 hour=self.hour, minute=self.minute, second=self.second,
+                 microsecond=self.microsecond, tzinfo=self.tzinfo)
+        d.update(**kw)
+        return datetime(**d)
+
+    def strftime(self, format):
+        """.. Note :: To show correct value for some formatting specials, e.g.
+        '%s' libjalali's :func:`jstrftime` needs timezone informations filled
+        in struct_jtm.tm_gmtoff which we could not depend on here, since naive
+        datetime objects have zero knowledge about it.  Storing these timezone
+        information in a naive datetime object, make datetime implementation
+        heavily depended on :func:`jmktime` which have several issues itself.
+        Additionally it makes :class:`~pyjalali.datetime.datetime` less like
+        :class:`datetime.datetime` since it should store more information and
+        change method signatures.
+
+        So consider returned values for every switch depended to timezone
+        information, like '%s' is wrong.
+        """
+        if not self.__have_yday_wday:
+            self._compute_wday_yday()        
+        return jstrftime(format, self.jtm)
+    
+    @classmethod
+    def strptime(self, date_str, format):
+        return jdatetime_from_jtm(jstrptime(format, date_str))
+
+    def timetuple(self):
+        njtm = self.jtm.copy()
+        jalali_update(njtm)
+        if self.dst() is None:
+            njtm.tm_isdst = -1
+        elif self.dst() == 0:
+            njtm.tm_isdst = 0
+        else:
+            njtm.tm_isdst = 1
+        return jtm_to_struct_time(njtm)
+
+    def utctimetuple(self):
+        if self.tzinfo is None:
+            d = self
+        else:
+            d = self.replace(tzinfo=None) - self.utcoffset()
+        njtm = d.jtm.copy()
+        jalali_update(njtm)
+        return jtm_to_struct_time(njtm)
+
+    def time(self):
+        return _std_dt_mod.time(self.hour, self.minute, self.second)
+    
+    def timetz(self):
+        return _std_dt_mod.time(self.hour, self.minute, self.second,
+                                self.tzinfo)
+
+    @classmethod
+    def today(self):
+        return now()
+
+    def tzname(self):
+        if self.tzinfo is None:
+            return
+        rv = self.tzinfo.tzname(self)
+        if rv is None or isinstance(rv, str):
+            return rv
+        raise TypeError("tzinfo.tzname() must return None or a str, not " \
+                        "'%s'" % self.__class__.__name__)
+
+    def utcoffset(self):
+        """
+        >>> from pytz import timezone,AmbiguousTimeError,NonExistentTimeError
+        >>> timezone('Asia/Tehran').utcoffset(datetime(1390, 1, 1, 10, 2))
+        datetime.timedelta(0, 12600)
+        >>> timezone('Asia/Tehran').utcoffset(datetime(1390, 6, 30, 22, 30))
+        datetime.timedelta(0, 16200)
+        >>> ambiguous = datetime(1392, 6, 30, 23, 30)
+        >>> try:
+        ...     timezone('Asia/Tehran').utcoffset(ambiguous)
+        ... except AmbiguousTimeError:
+        ...     print "caught"
+        caught
+        >>> non_existent = datetime(1390, 1, 2, 0, 45)
+        >>> try:
+        ...     timezone('Asia/Tehran').utcoffset(non_existent)
+        ... except NonExistentTimeError:
+        ...     print "caught"
+        caught
+        """
+        if self.tzinfo is None:
+            return
+        rv = self.tzinfo.utcoffset(self)
+        if rv is None or isinstance(rv, _std_dt_mod.timedelta):
+            return rv
+        raise TypeError("tzinfo.utcoffset() must return None or a timedelta, "\
+                        "not '%s'" % rv.__class__.__name__)
+
+    @classmethod
+    def utcfromtimestamp(self, ts):
+        return jdatetime_from_ts(ts, False)
+
+    @classmethod
+    def utcnow(self):
+        return utcnow()
+
+
+datetime.min = datetime(1,1,1)
+#XXX: not sure, ask ashkan
+datetime.max = datetime(9999, 12, 29, 23, 59, 59)
+datetime.resolution = _std_dt_mod.timedelta(seconds=1)
+
+date.__format__ = datetime.__format__ = lambda s, f: s.strftime(f)
+date.weekday = datetime.weekday = lambda self: self.jtm.tm_wday
+date.isoweekday = datetime.isoweekday = lambda self: self.jtm.tm_wday + 1
+
+
+def now(timezone=None):
+    return jdatetime_from_ts(_timestamp(), True, tz=timezone)
+
+
+def utcnow():
+    return jdatetime_from_ts(_timestamp(), False)
+
+
+def jdatetime_from_ts(ts, local, tz=None):
+    uts = int(ts % 1 * 1000000)
+    tts = int(ts)
+    if local and tz is None:
+        jtm = jlocaltime_r(tts)
+    else:
+        if local:
+            return tz.fromutc(datetime.utcfromtimestamp(ts))
+        assert tz is None
+        jtm = jgmtime_r(tts)
+    return jdatetime_from_jtm(jtm, uts, tz)
+
+
+def jdatetime_from_dt(dt):
+    """Make Jalali datetime from Gregorian datetime
+    >>> from datetime import datetime as _dtm
+    >>> jdatetime_from_dt(_dtm(2013, 11, 23, 23, 46, 0, 703498))
+    pyjalali.datetime.datetime(1392, 9, 2, 23, 46, 0, 703498)
+    >>> jdatetime_from_dt(_dtm(2013, 4, 13, 21, 10, 2, 292))
+    pyjalali.datetime.datetime(1392, 1, 24, 21, 10, 2, 292)
+    >>> jdatetime_from_dt(_dtm(2013, 3, 22, 0, 12))
+    pyjalali.datetime.datetime(1392, 1, 2, 0, 12, 0, 0)
+    """
+    if not isinstance(dt, _std_dt_mod.datetime):
+        raise TypeError('Expected %s instance' % _std_dt_mod.datetime)
+    ndt = dt.replace(hour=12, minute=0, second=0) # no dst changes here
+    ts = mktime(ndt.timetuple())
+    return datetime.fromtimestamp(ts).replace(hour=dt.hour, minute=dt.minute,
+           second=dt.second, microsecond=dt.microsecond)
+
+
+def dt_from_jdatetime(jdt):
+    """Make gregorian datetime from Jalali datetime
+    >>> dt_from_jdatetime(datetime(1392, 9, 2, 23, 10, 2))
+    datetime.datetime(2013, 11, 23, 23, 10, 2)
+    >>> dt_from_jdatetime(datetime(1392, 6, 30, 22, 30))
+    datetime.datetime(2013, 9, 21, 22, 30)
+    """
+    if not isinstance(jdt, datetime):
+        raise TypeError
+    njtm = jdt.jtm.copy()
+    # to stop dst changes from bugging conversion, just convert date
+    njtm.tm_hour = njtm.tm_min = njtm.tm_sec = 12
+    #TODO: change after jmktime fix
+    jalali_update(njtm) # pragma: jmktime needs yday
+    return _std_dt_mod.datetime.fromtimestamp(jmktime(njtm)) \
+            .replace(hour=jdt.hour, minute=jdt.minute, second=jdt.second,
+                     microsecond=jdt.microsecond, tzinfo=jdt.tzinfo)
+
+
+def jdatetime_from_jtm(jtm, microsecond=0, tz=None):
+    jdt = datetime(*jtm_to_struct_time(jtm)[:6], microsecond=microsecond, tzinfo=tz)
+    return jdt

--- a/sources/pyjalali/helpers.py
+++ b/sources/pyjalali/helpers.py
@@ -1,0 +1,94 @@
+"""
+    pyjalali.helpers
+    ~~~~~~~~~~~~~~~~
+
+    >>> normalized_date_time(1387, 10, 15, 20, 59, 58, 2000100)
+    (1387, 10, 15, 21, 0, 0, 100)
+    >>> normalized_date (1391, 11, 30) # leap year
+    (1391, 11, 30)
+    >>> normalized_date (1390, 12, 1)
+    (1391, 0, 1)
+    >>> normalized_date (1390, 11, 30)
+    (1391, 0, 1)
+    >>> normalized_date (1390, 0, 1)
+    (1390, 0, 1)
+    >>> normalized_date (1390, 0, 0)
+    (1389, 11, 29)
+    >>> normalized_date (1391, 0, 0) # leap year, one day befor
+    (1390, 11, 29)
+    >>> normalized_date (1392, 0, 0)
+    (1391, 11, 30)
+    >>> normalized_date (1392, 11, -32)
+    (1392, 9, 28)
+    >>> normalized_date (1389, 11, 130)
+    (1390, 3, 8)
+    >>> normalized_date (1388, 4, 32)
+    (1388, 5, 1)
+
+"""
+
+from pyjalali.jalali import jalali_is_jleap
+
+days_in_month = (31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29)
+
+def normalized_pair(hi, lo, factor):
+    assert factor > 0
+    if lo < 0 or lo >= factor:
+        hix, lo = divmod(lo, factor)
+        hi += hix
+    return hi, lo
+
+
+def month_days(year, mon):
+    mon %= 12
+    dim = days_in_month[mon]
+    if mon == 11 and jalali_is_jleap(year):
+        dim += 1
+    return dim
+
+
+def normalized_date(year, mon, mday):
+    if mon < 0 or mon > 11:
+        year, mon = normalized_pair(year, mon, 12)
+    assert 0 <= mon <= 11
+
+    dim = month_days(year, mon)
+    if mday > dim:
+        while mday > dim:
+            mday -= dim
+            mon += 1
+            dim = month_days(year, mon)
+        return normalized_date(year, mon, mday)
+    del dim
+    while mday < 1:
+        # break month to day
+        if mon == 0:
+            year -= 1
+            mon += 11
+        else:
+            mon -= 1
+        mday += month_days(year, mon)
+
+    assert 0 <= mon <= 11
+    assert 1 <= mday <= month_days(year, mon)
+    return year, mon, mday
+
+
+def normalized_date_time(year, mon, mday, hour, min, sec, ms):
+    """
+    0 <= mon <= 11
+    1 <= mday <= 31
+    """
+    sec, ms = normalized_pair(sec, ms, 1000000)
+    min, sec = normalized_pair(min, sec, 60)
+    hour, min = normalized_pair(hour, min, 60)
+    mday, hour = normalized_pair(mday, hour, 24)
+    return normalized_date(year, mon, mday) + (hour, min, sec, ms)
+
+
+def normalize_jtm(jtm, microsecond=0):
+    (jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour,
+        jtm.tm_min, jtm.tm_sec, microsecond) = normalized_date_time (
+            jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour, \
+            jtm.tm_min, jtm.tm_sec, microsecond)
+    return microsecond

--- a/sources/pyjalali/helpers.py
+++ b/sources/pyjalali/helpers.py
@@ -30,16 +30,6 @@
 from pyjalali.jalali import jalali_is_jleap
 
 days_in_month = (31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29)
-# accumulated_month_days = (0, 31, 62, 93, 124, 155, 186, 216, 246, 276, 306,
-                          # 336)
-
-
-# def get_yday(year, month, mday):
-    # """
-        # Assumes valid input
-        # 0 <= month <= 11
-    # """
-    # return accumulated_month_days[month] + mday - 1
 
 
 def normalized_pair(hi, lo, factor):
@@ -59,6 +49,8 @@ def month_days(year, mon):
 
 
 def normalized_date(year, mon, mday):
+    # this usage should be integrated in jmktime probably
+    # TODO
     if mon < 0 or mon > 11:
         year, mon = normalized_pair(year, mon, 12)
     assert 0 <= mon <= 11

--- a/sources/pyjalali/helpers.py
+++ b/sources/pyjalali/helpers.py
@@ -30,6 +30,17 @@
 from pyjalali.jalali import jalali_is_jleap
 
 days_in_month = (31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29)
+# accumulated_month_days = (0, 31, 62, 93, 124, 155, 186, 216, 246, 276, 306,
+                          # 336)
+
+
+# def get_yday(year, month, mday):
+    # """
+        # Assumes valid input
+        # 0 <= month <= 11
+    # """
+    # return accumulated_month_days[month] + mday - 1
+
 
 def normalized_pair(hi, lo, factor):
     assert factor > 0
@@ -88,7 +99,7 @@ def normalized_date_time(year, mon, mday, hour, min, sec, ms):
 
 def normalize_jtm(jtm, microsecond=0):
     (jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour,
-        jtm.tm_min, jtm.tm_sec, microsecond) = normalized_date_time (
-            jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour, \
+        jtm.tm_min, jtm.tm_sec, microsecond) = normalized_date_time(
+            jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour,
             jtm.tm_min, jtm.tm_sec, microsecond)
     return microsecond

--- a/sources/pyjalali/jalali.py
+++ b/sources/pyjalali/jalali.py
@@ -1,0 +1,84 @@
+"""
+    pyjalali.jalali
+    ~~~~~~~~~~~~~~~
+
+    libjalali custom functions.
+"""
+
+from pyjalali import _libj
+from pyjalali.types import struct_ab_jtm, struct_jtm, struct_jyinfo, time_t
+from ctypes import POINTER, byref, c_int
+
+__all__ = ('jalali_create_date_from_days', 'jalali_create_date_from_days',
+           'jalali_create_secs_from_time', 'jalali_create_time_from_secs',
+           'jalali_get_date', 'jalali_get_diff', 'jalali_get_jyear_info',
+           'jalali_is_jleap', 'jalali_update')
+
+_jalali_is_jleap = _libj.jalali_is_jleap
+_jalali_is_jleap.argtypes = (c_int,)
+_jalali_is_jleap.restype = c_int
+def jalali_is_jleap(year):
+    return _jalali_is_jleap(year) == 1
+
+
+_jalali_create_time_from_secs = _libj.jalali_create_time_from_secs
+_jalali_create_time_from_secs.argtypes = (time_t, POINTER(struct_ab_jtm))
+def jalali_create_time_from_secs(timestamp):
+    res = struct_ab_jtm()
+    _jalali_create_time_from_secs(timestamp, byref(res))
+    return res
+
+
+_jalali_create_secs_from_time = _libj.jalali_create_secs_from_time
+_jalali_create_secs_from_time.argtypes = (POINTER(struct_ab_jtm),)
+_jalali_create_secs_from_time.restype = time_t
+def jalali_create_secs_from_time(ab_jtm):
+    #XXX: ret sanity check
+    return _jalali_create_secs_from_time(bref(ab_jtm)).value
+
+
+_jalali_create_date_from_days = _libj.jalali_create_date_from_days
+_jalali_create_date_from_days.argtypes = (POINTER(struct_jtm),)
+def jalali_create_date_from_days(j_date, silent=False):
+    res = _jalali_create_date_from_days(byref(j_date))
+    if res == -1 and not silent:
+        raise ValueError
+
+
+_jalali_create_days_from_date = _libj.jalali_create_days_from_date
+_jalali_create_days_from_date.argtypes = (POINTER(struct_jtm),)
+def jalali_create_days_from_date(j_date, silent=False):
+    res = _jalali_create_days_from_date(byref(j_date))
+    if res == -1 and not silent:
+        raise ValueError
+
+
+_jalali_get_jyear_info = _libj.jalali_get_jyear_info
+_jalali_get_jyear_info.argtypes = (POINTER(struct_jyinfo),)
+def jalali_get_jyear_info(jyinfo):
+    _jalali_get_jyear_info(byref(jyinfo))
+
+
+_jalali_get_date = _libj.jalali_get_date
+_jalali_get_date.argtypes = (c_int, POINTER(struct_jtm))
+def jalali_get_date(year):
+    res = struct_jtm()
+    _jalali_get_date(year, byref(res))
+    return res
+
+
+_jalali_get_diff = _libj.jalali_get_diff
+_jalali_get_diff.argtypes = (POINTER(struct_jtm),)
+def jalali_get_diff(j_date):
+    if _jalali_get_diff(byref(j_date)) == -1:
+       raise ValueError 
+
+
+_jalali_update = _libj.jalali_update
+_jalali_update.argtypes = (POINTER(struct_jtm),)
+def jalali_update(j_date):
+    """
+    this doesn't set isdst
+    """
+    if _jalali_update(byref(j_date)) != 0:
+        raise ValueError

--- a/sources/pyjalali/jalali.py
+++ b/sources/pyjalali/jalali.py
@@ -77,8 +77,5 @@ def jalali_get_diff(j_date):
 _jalali_update = _libj.jalali_update
 _jalali_update.argtypes = (POINTER(struct_jtm),)
 def jalali_update(j_date):
-    """
-    this doesn't set isdst
-    """
     if _jalali_update(byref(j_date)) != 0:
         raise ValueError

--- a/sources/pyjalali/jalali.py
+++ b/sources/pyjalali/jalali.py
@@ -71,7 +71,7 @@ _jalali_get_diff = _libj.jalali_get_diff
 _jalali_get_diff.argtypes = (POINTER(struct_jtm),)
 def jalali_get_diff(j_date):
     if _jalali_get_diff(byref(j_date)) == -1:
-       raise ValueError 
+        raise ValueError
 
 
 _jalali_update = _libj.jalali_update

--- a/sources/pyjalali/jstr.py
+++ b/sources/pyjalali/jstr.py
@@ -15,7 +15,7 @@ __all__ = ['jstrftime', 'jstrptime']
 _jstrptime = _libj.jstrptime
 _jstrptime.argtypes = (c_char_p, c_char_p, POINTER(struct_jtm))
 _jstrptime.restype = c_char_p
-def jstrptime(date_str, format):
+def jstrptime(format, date_str):
     """Return date from date_str according to format
     :param date_str: string
     :param format: string
@@ -28,7 +28,7 @@ def jstrptime(date_str, format):
 
 _jstrftime = _libj.jstrftime
 _jstrftime.argtypes = (c_char_p, c_int, c_char_p, POINTER(struct_jtm))
-def jstrftime(j_date, format):
+def jstrftime(format, j_date):
     """Return string representation of date according to format
     :param date: struct_jtm
     :param format: string

--- a/sources/pyjalali/jstr.py
+++ b/sources/pyjalali/jstr.py
@@ -33,7 +33,7 @@ def jstrftime(j_date, format):
     :param date: struct_jtm
     :param format: string
     """
-    n = len(format) << 2
+    n = len(format) << 8
     res = create_string_buffer(n)
     _jstrftime(res, n, format, byref(j_date))
     return res.value

--- a/sources/pyjalali/jstr.py
+++ b/sources/pyjalali/jstr.py
@@ -1,0 +1,39 @@
+"""
+    pyjalali.jstr
+    ~~~~~~~~~~~~~
+
+    String formatting and deformatting.
+"""
+
+from pyjalali import _libj
+from pyjalali.types import struct_jtm
+from ctypes import POINTER, byref
+from ctypes import c_char_p, c_int, create_string_buffer
+
+__all__ = ['jstrftime', 'jstrptime']
+
+_jstrptime = _libj.jstrptime
+_jstrptime.argtypes = (c_char_p, c_char_p, POINTER(struct_jtm))
+_jstrptime.restype = c_char_p
+def jstrptime(date_str, format):
+    """Return date from date_str according to format
+    :param date_str: string
+    :param format: string
+    """
+    date = struct_jtm()
+    res = c_char_p()
+    res = _jstrptime(date_str, format, byref(date))
+    return date, res
+
+
+_jstrftime = _libj.jstrftime
+_jstrftime.argtypes = (c_char_p, c_int, c_char_p, POINTER(struct_jtm))
+def jstrftime(j_date, format):
+    """Return string representation of date according to format
+    :param date: struct_jtm
+    :param format: string
+    """
+    n = len(format) << 2
+    res = create_string_buffer(n)
+    _jstrftime(res, n, format, byref(j_date))
+    return res.value

--- a/sources/pyjalali/jtime.py
+++ b/sources/pyjalali/jtime.py
@@ -10,15 +10,10 @@
 """
 
 from pyjalali import _libj
-from pyjalali.types import (struct_ab_jtm, struct_jtm, struct_jyinfo, time_t,
-                            time_t_p)
-from ctypes import POINTER, byref, c_char_p, c_int, create_string_buffer
+from pyjalali.types import struct_jtm, time_t, time_t_p
+from ctypes import POINTER, byref, c_char_p, create_string_buffer
 
-__all__ = ('jalali_create_date_from_days', 'jalali_create_date_from_days',
-           'jalali_create_secs_from_time', 'jalali_create_time_from_secs',
-           'jalali_get_date', 'jalali_get_diff', 'jalali_get_jyear_info',
-           'jalali_is_jleap', '_jalali_update', 'jasctime_r', 'jctime_r',
-           'jgmtime_r', 'jlocaltime_r', 'jmktime')
+__all__ = ('jasctime_r', 'jctime_r', 'jgmtime_r', 'jlocaltime_r', 'jmktime')
 
 
 _jasctime_r = _libj.jasctime_r
@@ -75,70 +70,10 @@ def jmktime(j_date):
     """Return timestamp from broken-down j_date according to local timezone and
     dst settings
     :param j_date: struct_jtm
+
+    Inconsistenices with POSIX jmktime:
+    1. it doesn't normalize
+    2. it needs glibc defined timezone information.
+    3. it needs yday
     """
     return _jmktime(byref(j_date))
-
-
-_jalali_is_jleap = _libj.jalali_is_jleap
-_jalali_is_jleap.argtypes = (c_int,)
-_jalali_is_jleap.restype = c_int
-def jalali_is_jleap(year):
-    return _jalali_is_jleap(year) == 1
-
-
-_jalali_create_time_from_secs = _libj.jalali_create_time_from_secs
-_jalali_create_time_from_secs.argtypes = (time_t, POINTER(struct_ab_jtm))
-def jalali_create_time_from_secs(timestamp):
-    res = struct_ab_jtm()
-    _jalali_create_time_from_secs(timestamp, byref(res))
-    return res
-
-
-_jalali_create_secs_from_time = _libj.jalali_create_secs_from_time
-_jalali_create_secs_from_time.argtypes = (POINTER(struct_ab_jtm),)
-_jalali_create_secs_from_time.restype = time_t
-def jalali_create_secs_from_time(ab_jtm):
-    #XXX: ret sanity check
-    return _jalali_create_secs_from_time(bref(ab_jtm)).value
-
-
-_jalali_create_date_from_days = _libj.jalali_create_date_from_days
-_jalali_create_date_from_days.argtypes = (POINTER(struct_jtm),)
-def jalali_create_date_from_days(j_date, silent=False):
-    res = _jalali_create_date_from_days(byref(j_date))
-    if res == -1 and not silent:
-        raise ValueError
-
-
-_jalali_create_days_from_date = _libj.jalali_create_days_from_date
-_jalali_create_days_from_date.argtypes = (POINTER(struct_jtm),)
-def jalali_create_days_from_date(j_date, silent=False):
-    res = _jalali_create_days_from_date(byref(j_date))
-    if res == -1 and not silent:
-        raise ValueError
-
-
-_jalali_get_jyear_info = _libj.jalali_get_jyear_info
-_jalali_get_jyear_info.argtypes = (POINTER(struct_jyinfo),)
-def jalali_get_jyear_info(jyinfo):
-    _jalali_get_jyear_info(byref(jyinfo))
-
-
-_jalali_get_date = _libj.jalali_get_date
-_jalali_get_date.argtypes = (c_int, POINTER(struct_jtm))
-def jalali_get_date(year):
-    res = struct_jtm()
-    _jalali_get_date(year, byref(res))
-    return res
-
-
-_jalali_get_diff = _libj.jalali_get_diff
-_jalali_get_diff.argtypes = (POINTER(struct_jtm),)
-def jalali_get_diff(j_date):
-    return _jalali_get_diff(byref(j_date))
-
-
-_jalali_update = _libj.jalali_update
-_jalali_update.argtypes = (POINTER(struct_jtm),)
-def jalali_update(j_date):
-    _jalali_update(byref(j_date))

--- a/sources/pyjalali/jtime.py
+++ b/sources/pyjalali/jtime.py
@@ -125,9 +125,9 @@ def jalali_get_jyear_info(jyinfo):
 
 
 _jalali_get_date = _libj.jalali_get_date
-_jalali_get_date.argtypes = (c_int, POINTER(struct_jyinfo))
+_jalali_get_date.argtypes = (c_int, POINTER(struct_jtm))
 def jalali_get_date(year):
-    res = struct_jyinfo()
+    res = struct_jtm()
     _jalali_get_date(year, byref(res))
     return res
 

--- a/sources/pyjalali/jtime.py
+++ b/sources/pyjalali/jtime.py
@@ -1,0 +1,144 @@
+"""
+    pyjalali.time
+    ~~~~~~~~~~~~~
+
+    Time functions.
+
+    .. Note :: Functions `jasctime`, `jctime`, `jgmtime` and `jlocaltime` not
+    implemented.  Those are not thread-safe and there is no need for them in
+    Python.
+"""
+
+from pyjalali import _libj
+from pyjalali.types import (struct_ab_jtm, struct_jtm, struct_jyinfo, time_t,
+                            time_t_p)
+from ctypes import POINTER, byref, c_char_p, c_int, create_string_buffer
+
+__all__ = ('jalali_create_date_from_days', 'jalali_create_date_from_days',
+           'jalali_create_secs_from_time', 'jalali_create_time_from_secs',
+           'jalali_get_date', 'jalali_get_diff', 'jalali_get_jyear_info',
+           'jalali_is_jleap', '_jalali_update', 'jasctime_r', 'jctime_r',
+           'jgmtime_r', 'jlocaltime_r', 'jmktime')
+
+
+_jasctime_r = _libj.jasctime_r
+_jasctime_r.argtypes = (POINTER(struct_jtm), c_char_p)
+def jasctime_r(j_date, retain_nl=False):
+    """Return string representation of jalali date from broken-down jdate
+    :param date: struct_jtm
+    :param retain_nl: bool
+    """
+    res = create_string_buffer(26)
+    _jasctime_r(byref(j_date), res)
+    return res.value if retain_nl else res.value[:-1]
+
+
+_jctime_r = _libj.jctime_r
+_jctime_r.argtypes = (time_t_p, c_char_p)
+def jctime_r(timestamp, retain_nl=False):
+    """Return string representation of jalali date from timestamp
+    :param timestamp: int
+    :param retain_nl: bool
+    """
+    res = create_string_buffer(26)
+    _jctime_r(byref(time_t(timestamp)), res)
+    return res.value if retain_nl else res.value[:-1]
+
+
+_jgmtime_r = _libj.jgmtime_r
+_jgmtime_r.argtypes = (time_t_p, POINTER(struct_jtm))
+def jgmtime_r(timestamp):
+    """Make jalali broken-down date from timestamp
+    :param timestamp: int
+    """
+    res = struct_jtm()
+    _jgmtime_r(byref(time_t(timestamp)), byref(res))
+    return res
+
+
+_jlocaltime_r = _libj.jlocaltime_r
+_jlocaltime_r.argtypes = (time_t_p, POINTER(struct_jtm))
+def jlocaltime_r(timestamp):
+    """Make jalali broken-down date from timestamp according to local zone and
+    dst settings
+    :param timestamp: int
+    """
+    res = struct_jtm()
+    _jlocaltime_r(byref(time_t(timestamp)), byref(res))
+    return res
+
+
+_jmktime = _libj.jmktime
+_jmktime.argtypes = (POINTER(struct_jtm),)
+_jmktime.restype = time_t
+def jmktime(j_date):
+    """Return timestamp from broken-down j_date according to local timezone and
+    dst settings
+    :param j_date: struct_jtm
+    """
+    return _jmktime(byref(j_date))
+
+
+_jalali_is_jleap = _libj.jalali_is_jleap
+_jalali_is_jleap.argtypes = (c_int,)
+_jalali_is_jleap.restype = c_int
+def jalali_is_jleap(year):
+    return _jalali_is_jleap(year) == 1
+
+
+_jalali_create_time_from_secs = _libj.jalali_create_time_from_secs
+_jalali_create_time_from_secs.argtypes = (time_t, POINTER(struct_ab_jtm))
+def jalali_create_time_from_secs(timestamp):
+    res = struct_ab_jtm()
+    _jalali_create_time_from_secs(timestamp, byref(res))
+    return res
+
+
+_jalali_create_secs_from_time = _libj.jalali_create_secs_from_time
+_jalali_create_secs_from_time.argtypes = (POINTER(struct_ab_jtm),)
+_jalali_create_secs_from_time.restype = time_t
+def jalali_create_secs_from_time(ab_jtm):
+    #XXX: ret sanity check
+    return _jalali_create_secs_from_time(bref(ab_jtm)).value
+
+
+_jalali_create_date_from_days = _libj.jalali_create_date_from_days
+_jalali_create_date_from_days.argtypes = (POINTER(struct_jtm),)
+def jalali_create_date_from_days(j_date, silent=False):
+    res = _jalali_create_date_from_days(byref(j_date))
+    if res == -1 and not silent:
+        raise ValueError
+
+
+_jalali_create_days_from_date = _libj.jalali_create_days_from_date
+_jalali_create_days_from_date.argtypes = (POINTER(struct_jtm),)
+def jalali_create_days_from_date(j_date, silent=False):
+    res = _jalali_create_days_from_date(byref(j_date))
+    if res == -1 and not silent:
+        raise ValueError
+
+
+_jalali_get_jyear_info = _libj.jalali_get_jyear_info
+_jalali_get_jyear_info.argtypes = (POINTER(struct_jyinfo),)
+def jalali_get_jyear_info(jyinfo):
+    _jalali_get_jyear_info(byref(jyinfo))
+
+
+_jalali_get_date = _libj.jalali_get_date
+_jalali_get_date.argtypes = (c_int, POINTER(struct_jyinfo))
+def jalali_get_date(year):
+    res = struct_jyinfo()
+    _jalali_get_date(year, byref(res))
+    return res
+
+
+_jalali_get_diff = _libj.jalali_get_diff
+_jalali_get_diff.argtypes = (POINTER(struct_jtm),)
+def jalali_get_diff(j_date):
+    return _jalali_get_diff(byref(j_date))
+
+
+_jalali_update = _libj.jalali_update
+_jalali_update.argtypes = (POINTER(struct_jtm),)
+def jalali_update(j_date):
+    _jalali_update(byref(j_date))

--- a/sources/pyjalali/types.py
+++ b/sources/pyjalali/types.py
@@ -1,0 +1,53 @@
+"""
+    pyjalali.types
+    ~~~~~~~~~~~~~~
+
+    Core C types for libjalali binding.
+"""
+
+from ctypes import POINTER, Structure, c_char_p, c_int, c_long
+
+class struct_ab_jtm(Structure):
+    """Time passed since UTC Epoch"""
+    _fields_ = (('ab_sec', c_int),
+                ('ab_min', c_int),
+                ('ab_hour', c_int),
+                ('ab_days', c_int))
+
+    def __str__(self):
+        return '%d %d-%d%d' % (self.ab_days, self.ab_hour, self.ab_min,
+                               self.ab_sec)
+
+
+class struct_jtm(Structure):
+    """Broken-down jalali date and time"""
+    _fields_ = (('tm_sec', c_int),
+                ('tm_min', c_int),
+                ('tm_hour', c_int),
+                ('tm_mday', c_int),
+                ('tm_mon', c_int),
+                ('tm_year', c_int),
+                ('tm_wday', c_int),
+                ('tm_yday', c_int),
+                ('tm_isdst', c_int),
+                ('tm_gmtoff', c_long),
+                ('tm_zone', c_char_p))
+
+    def __str__(self):
+        return '%d/%d/%d %d-%d-%d' % (self.tm_year, self.tm_mon, self.tm_mday,
+                                     self.tm_hour, self.tm_min, self.tm_sec)
+
+
+class struct_jyinfo(Structure):
+    """Year specific information"""
+    _fields_ = (('lf', c_int),
+                ('y', c_int),
+                ('r', c_int),
+                ('p', c_int),
+                ('rl', c_int),
+                ('pl', c_int),
+                ('apl', c_int))
+
+
+time_t = c_int
+time_t_p = POINTER(c_int)

--- a/sources/pyjalali/types.py
+++ b/sources/pyjalali/types.py
@@ -6,6 +6,7 @@
 """
 
 from ctypes import POINTER, Structure, c_char_p, c_int, c_long
+from time import struct_time
 
 class struct_ab_jtm(Structure):
     """Time passed since UTC Epoch"""
@@ -34,8 +35,15 @@ class struct_jtm(Structure):
                 ('tm_zone', c_char_p))
 
     def __str__(self):
-        return '%d/%d/%d %d-%d-%d' % (self.tm_year, self.tm_mon, self.tm_mday,
-                                     self.tm_hour, self.tm_min, self.tm_sec)
+        return '%d/%d/%d %d-%d-%d +%d (%s)' % (self.tm_year, self.tm_mon,
+                                              self.tm_mday, self.tm_hour,
+                                              self.tm_min, self.tm_sec,
+                                              self.tm_gmtoff, self.tm_zone)
+    def copy(self):
+        return struct_jtm(self.tm_sec, self.tm_min, self.tm_hour, self.tm_mday,
+                          self.tm_mon, self.tm_year, self.tm_wday,
+                          self.tm_yday, self.tm_isdst, self.tm_gmtoff,
+                          self.tm_zone)
 
 
 class struct_jyinfo(Structure):
@@ -51,3 +59,8 @@ class struct_jyinfo(Structure):
 
 time_t = c_int
 time_t_p = POINTER(c_int)
+
+def jtm_to_struct_time(src_jtm):
+    return struct_time((src_jtm.tm_year, src_jtm.tm_mon+1, src_jtm.tm_mday,
+                        src_jtm.tm_hour, src_jtm.tm_min, src_jtm.tm_sec,
+                        src_jtm.tm_wday, src_jtm.tm_yday+1, src_jtm.tm_isdst))

--- a/sources/setup.py
+++ b/sources/setup.py
@@ -1,0 +1,25 @@
+#!/bin/env python
+
+import os
+from distutils.core import setup
+
+try:
+    src_p = os.path.dirname(os.path.abspath(__file__))
+    mkfile_p = os.path.join(src_p, 'libjalali', 'Makefile.am')
+    with open(mkfile_p) as mkfile:
+        content = mkfile.read()
+        snt = '-version-info'
+        pos = content.find(snt)
+        assert pos > -1
+        vpos = pos + len(snt) + 1
+        __version__ = content[vpos:].split('\n', 1)[0].replace(':','.')
+except:
+    __version__ = 'unknown'
+
+setup(
+        name='pyjalali',
+        description='Jalali calendar tools based on libjalali',
+        url='http://github.com/ashkang/jcal',
+        version=__version__,
+        packages=['pyjalali']
+)

--- a/sources/setup.py
+++ b/sources/setup.py
@@ -1,25 +1,29 @@
 #!/bin/env python
 
 import os
+import sys
 from distutils.core import setup
+src_p = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, src_p)
+import pyjalali
 
-try:
-    src_p = os.path.dirname(os.path.abspath(__file__))
-    mkfile_p = os.path.join(src_p, 'libjalali', 'Makefile.am')
-    with open(mkfile_p) as mkfile:
-        content = mkfile.read()
-        snt = '-version-info'
-        pos = content.find(snt)
-        assert pos > -1
-        vpos = pos + len(snt) + 1
-        __version__ = content[vpos:].split('\n', 1)[0].replace(':','.')
-except:
-    __version__ = 'unknown'
+version = '.'.join(map(str, pyjalali.__version__))
 
 setup(
         name='pyjalali',
         description='Jalali calendar tools based on libjalali',
+        long_description=pyjalali.__doc__.replace(' '*4, ''),
         url='http://github.com/ashkang/jcal',
-        version=__version__,
-        packages=['pyjalali']
+        license='GPLv3',
+        version=version,
+
+        packages=['pyjalali'],
+
+        classifiers = [
+            'Development Status :: 3 - Alpha',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+            'Topic :: Software Development :: Libraries :: Python Modules',
+            'Topic :: Software Development :: Localization'
+        ]
 )


### PR DESCRIPTION
This adds Python bindings for libjalali functions.  These functions could be imported from `jstr`, `jtime` and `jalali` modules.

Also a `datetime` implementation and related converters proposed in `datetime` module.  There is some issues in `jalali_update`, `jstrftime` and `jmktime` which still can make problem in this module but I've tried to call these functions with care.

Please test it.
