### PR TITLE
supposed reentrant versions of library functions such as localtime_r() are not really thread safe

### DIFF
--- a/sources/libjalali/jtime.c
+++ b/sources/libjalali/jtime.c
@@ -83,11 +83,10 @@ void in_jasctime(const struct jtm* jtm, char* buf)
         return;
 
     if (buf) {
-        snprintf(buf, MAX_BUF_SIZE, "%s %s %02d %02d:%02d:%02d %d\n",
+        sprintf(buf, "%s %s %02d %02d:%02d:%02d %d\n",
                  jalali_days_3[jtm->tm_wday], jalali_months_3[jtm->tm_mon],
                  jtm->tm_mday, jtm->tm_hour, jtm->tm_min, jtm->tm_sec,
                  jtm->tm_year);
-        memcpy(in_buf, buf, MAX_BUF_SIZE);
     } else {
     snprintf(in_buf, MAX_BUF_SIZE, "%s %s %02d %02d:%02d:%02d %d\n",
              jalali_days_3[jtm->tm_wday], jalali_months_3[jtm->tm_mon],
@@ -136,12 +135,8 @@ void in_jlocaltime(const time_t* timep, struct jtm* result)
     c_jtm.tm_isdst = t.tm_isdst;
 
     c_jtm.tm_gmtoff = gmtoff;
+    memcpy(result ? result : &in_jtm, &c_jtm, sizeof(struct jtm));
 
-    if (result) {
-        memcpy(result, &c_jtm, sizeof(struct jtm));
-    }
-
-    memcpy(&in_jtm, &c_jtm, sizeof(struct jtm));
 }
 
 void in_jctime(const time_t* timep, char* buf)
@@ -152,12 +147,7 @@ void in_jctime(const time_t* timep, char* buf)
     struct jtm c_jtm;
     in_jlocaltime(timep, &c_jtm);
 
-    if (buf) {
-        in_jasctime(&c_jtm, buf);
-    }
-    else {
-        in_jasctime(&c_jtm, 0);
-    }
+    in_jasctime(&c_jtm, buf ? buf : 0);
 }
 
 void in_jgmtime(const time_t* timep, struct jtm* result)
@@ -185,11 +175,8 @@ void in_jgmtime(const time_t* timep, struct jtm* result)
     c_jtm.tm_zone = GMT_ZONE;
     c_jtm.tm_gmtoff = 0;
 
-    if (result) {
-        memcpy(result, &c_jtm, sizeof(struct jtm));
-    }
+    memcpy(result ? result : &in_jtm, &c_jtm, sizeof(struct jtm));
 
-    memcpy(&in_jtm, &c_jtm, sizeof(struct jtm));
 }
 
 char* jasctime(const struct jtm* jtm)
@@ -851,8 +838,7 @@ char* jasctime_r(const struct jtm* jtm, char* buf)
         return 0;
 
     in_jasctime(jtm, buf);
-
-    return in_buf;
+    return buf;
 }
 
 struct jtm* jlocaltime_r(const time_t* timep, struct jtm* result)
@@ -861,8 +847,7 @@ struct jtm* jlocaltime_r(const time_t* timep, struct jtm* result)
         return 0;
 
     in_jlocaltime(timep, result);
-
-    return &in_jtm;
+    return result;
 }
 
 struct jtm* jgmtime_r(const time_t* timep, struct jtm* result)
@@ -871,8 +856,7 @@ struct jtm* jgmtime_r(const time_t* timep, struct jtm* result)
         return 0;
 
     in_jgmtime(timep, result);
-
-    return &in_jtm;
+    return result;
 }
 
 char* jctime_r(const time_t* timep, char* buf)
@@ -881,8 +865,7 @@ char* jctime_r(const time_t* timep, char* buf)
         return 0;
 
     in_jctime(timep, buf);
-
-    return in_buf;
+    return buf;
 }
 
 /*

--- a/sources/libjalali/jtime.c
+++ b/sources/libjalali/jtime.c
@@ -838,6 +838,7 @@ char* jasctime_r(const struct jtm* jtm, char* buf)
         return 0;
 
     in_jasctime(jtm, buf);
+    strncpy(in_buf, buf, MAX_BUF_SIZE);
     return buf;
 }
 
@@ -847,6 +848,7 @@ struct jtm* jlocaltime_r(const time_t* timep, struct jtm* result)
         return 0;
 
     in_jlocaltime(timep, result);
+    memcpy(&in_buf, result, sizeof(result));
     return result;
 }
 
@@ -856,6 +858,7 @@ struct jtm* jgmtime_r(const time_t* timep, struct jtm* result)
         return 0;
 
     in_jgmtime(timep, result);
+    memcpy(&in_buf, result, sizeof(result));
     return result;
 }
 
@@ -865,6 +868,7 @@ char* jctime_r(const time_t* timep, char* buf)
         return 0;
 
     in_jctime(timep, buf);
+    strncpy(in_buf, buf, MAX_BUF_SIZE);
     return buf;
 }
 

--- a/sources/pyjalali/jalali.py
+++ b/sources/pyjalali/jalali.py
@@ -18,12 +18,14 @@ _jalali_is_jleap = _libj.jalali_is_jleap
 _jalali_is_jleap.argtypes = (c_int,)
 _jalali_is_jleap.restype = c_int
 def jalali_is_jleap(year):
+    """Return True if given year is leap year else False."""
     return _jalali_is_jleap(year) == 1
 
 
 _jalali_create_time_from_secs = _libj.jalali_create_time_from_secs
 _jalali_create_time_from_secs.argtypes = (time_t, POINTER(struct_ab_jtm))
 def jalali_create_time_from_secs(timestamp):
+    """Return :class:`.types.struct_ab_jtm` from given timestamp."""
     res = struct_ab_jtm()
     _jalali_create_time_from_secs(timestamp, byref(res))
     return res
@@ -33,22 +35,35 @@ _jalali_create_secs_from_time = _libj.jalali_create_secs_from_time
 _jalali_create_secs_from_time.argtypes = (POINTER(struct_ab_jtm),)
 _jalali_create_secs_from_time.restype = time_t
 def jalali_create_secs_from_time(ab_jtm):
+    """Return number of seconds elapsed since UTC Epoch based on supplied
+    :class:`.types.struct_ab_jtm`.
+    """
     #XXX: ret sanity check
     return _jalali_create_secs_from_time(bref(ab_jtm)).value
 
 
 _jalali_create_date_from_days = _libj.jalali_create_date_from_days
 _jalali_create_date_from_days.argtypes = (POINTER(struct_jtm),)
-def jalali_create_date_from_days(j_date, silent=False):
-    res = _jalali_create_date_from_days(byref(j_date))
+def jalali_create_date_from_days(jtm, silent=False):
+    """Alter provided :class:`.types.struct_jtm` object's fields
+    :attr:`~.types.struct_jtm.tm_mon` and :attr:`~.types.struct_jtm.tm_mday`
+    based on its :attr:`~.types.struct_jtm.tm_yday` field.  In case of
+    failure raise `ValueError` exception if silent is not True.
+    """
+    res = _jalali_create_date_from_days(byref(jtm))
     if res == -1 and not silent:
         raise ValueError
 
 
 _jalali_create_days_from_date = _libj.jalali_create_days_from_date
 _jalali_create_days_from_date.argtypes = (POINTER(struct_jtm),)
-def jalali_create_days_from_date(j_date, silent=False):
-    res = _jalali_create_days_from_date(byref(j_date))
+def jalali_create_days_from_date(jtm, silent=False):
+    """Alter provided :class:`.types.struct_jtm` object's field
+    :attr:`~.types.struct_jtm.tm_yday` based on its fields
+    :attr:`~.types.struct_jtm.tm_mon` and :attr:`~.types.struct_jtm.tm_mday`.
+    In case of failure raise `ValueError` exception if silent is not True.
+    """
+    res = _jalali_create_days_from_date(byref(jtm))
     if res == -1 and not silent:
         raise ValueError
 
@@ -56,26 +71,41 @@ def jalali_create_days_from_date(j_date, silent=False):
 _jalali_get_jyear_info = _libj.jalali_get_jyear_info
 _jalali_get_jyear_info.argtypes = (POINTER(struct_jyinfo),)
 def jalali_get_jyear_info(jyinfo):
+    """Fill given :class:`.types.struct_jyinfo` object's fields with year
+    information based on given year by :attr:`.types.struct_jyinfo.y`.
+    """
     _jalali_get_jyear_info(byref(jyinfo))
 
 
 _jalali_get_date = _libj.jalali_get_date
 _jalali_get_date.argtypes = (c_int, POINTER(struct_jtm))
-def jalali_get_date(year):
+def jalali_get_date(days):
+    """Calculates Jalali date based on given number of days since UTC
+    Epoch and return result as :class:`.types.struct_jtm`.
+    """
     res = struct_jtm()
-    _jalali_get_date(year, byref(res))
+    _jalali_get_date(days, byref(res))
     return res
 
 
 _jalali_get_diff = _libj.jalali_get_diff
 _jalali_get_diff.argtypes = (POINTER(struct_jtm),)
-def jalali_get_diff(j_date):
-    if _jalali_get_diff(byref(j_date)) == -1:
+def jalali_get_diff(jtm, silent=False):
+    """Return number of days passed since UTC Epoch based on given
+    :class:`.types.struct_jtm`.  In case of failure raise `ValueError`
+    exception if silent is not True.
+    """
+    res = _jalali_get_diff(byref(jtm))
+    if res == -1 and not silent:
         raise ValueError
+    return res
 
 
 _jalali_update = _libj.jalali_update
 _jalali_update.argtypes = (POINTER(struct_jtm),)
-def jalali_update(j_date):
-    if _jalali_update(byref(j_date)) != 0:
-        raise ValueError
+def jalali_update(jtm):
+    """Updates given :class:`.types.struct_jtm` object's fields based on its
+    :attr:`~.types.struct_jtm.tm_year`, :attr:`~.types.struct_jtm.tm_mon` and
+    :attr:`~.types.struct_jtm.tm_mday`.
+    """
+    _jalali_update(byref(jtm))


### PR DESCRIPTION
`localtime_r()` updates the internal static jtm object first, then moves it's data into result structure. This is wrong, since multiple instances of re-entrant functions might do this resulting in a corrupted output. Re-entrant versions of library function calls must update results passed to them first, then update the static jtm object.
