### PR TITLE
jalali_update() must normalize according to POSIX specifications

### DIFF
--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -354,9 +354,9 @@ int jalali_get_diff(const struct jtm* j)
 /*
  * Number of days in provided year and month
  */
-static int jalali_year_month_days(int year, int month) {
+int jalali_year_month_days(int year, int month) {
     int dim = jalali_month_len[month];
-    if (jalali_is_jleap(year) && month == 11)
+    if (month == 11 && jalali_is_jleap(year))
         dim += 1;
     return dim;
 }

--- a/sources/libjalali/jalali.h
+++ b/sources/libjalali/jalali.h
@@ -86,6 +86,8 @@ extern void jalali_update(struct jtm* jtm);
 
 extern void jalali_show_time(const struct jtm* j);
 
+extern int jalali_year_month_days(int year, int month);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sources/pyjalali/datetime.py
+++ b/sources/pyjalali/datetime.py
@@ -15,11 +15,12 @@ from __future__ import absolute_import
 import datetime as _std_dt_mod
 from time import time as _timestamp, mktime, strftime
 
-from pyjalali.jalali import jalali_update, jalali_create_days_from_date
+from pyjalali.jalali import (jalali_update, jalali_create_days_from_date,
+                             jalali_year_month_days)
 from pyjalali.jtime import jctime, jgmtime, jlocaltime, jmktime
 from pyjalali.jstr import jstrftime, jstrptime
 from pyjalali.types import struct_jtm, jtm_to_struct_time
-from pyjalali.helpers import normalize_jtm, month_days
+from pyjalali.helpers import normalize_jtm
 
 
 __all__ = ('date', 'datetime', 'j2g', 'g2j', 'now', 'utcnow',
@@ -34,7 +35,7 @@ class date(object):
     def __init__(self, year, month, day):
         if not 1 <= month <= 12:
             raise ValueError('month value out of range [1, 12]')
-        if day > month_days(year, month - 1):
+        if day > jalali_year_month_days(year, month - 1):
             raise ValueError('day is out of range for month')
         self.__jtm = struct_jtm()
         self.__jtm.tm_year = year

--- a/sources/pyjalali/helpers.py
+++ b/sources/pyjalali/helpers.py
@@ -2,32 +2,34 @@
     pyjalali.helpers
     ~~~~~~~~~~~~~~~~
 
-    >>> normalized_date_time(1387, 10, 15, 20, 59, 58, 2000100)
-    (1387, 10, 15, 21, 0, 0, 100)
-    >>> normalized_date (1391, 11, 30) # leap year
+    >>> _normalized_date (1391, 11, 30) # leap year
     (1391, 11, 30)
-    >>> normalized_date (1390, 12, 1)
+    >>> _normalized_date (1390, 12, 1)
     (1391, 0, 1)
-    >>> normalized_date (1390, 11, 30)
+    >>> _normalized_date (1390, 11, 30)
     (1391, 0, 1)
-    >>> normalized_date (1390, 0, 1)
+    >>> _normalized_date (1390, 0, 1)
     (1390, 0, 1)
-    >>> normalized_date (1390, 0, 0)
+    >>> _normalized_date (1390, 0, 0)
     (1389, 11, 29)
-    >>> normalized_date (1391, 0, 0) # leap year, one day before
+    >>> _normalized_date (1391, 0, 0) # leap year, one day before
     (1390, 11, 29)
-    >>> normalized_date (1392, 0, 0)
+    >>> _normalized_date (1392, 0, 0)
     (1391, 11, 30)
-    >>> normalized_date (1392, 11, -32)
+    >>> _normalized_date (1392, 11, -32)
     (1392, 9, 28)
-    >>> normalized_date (1389, 11, 130)
+    >>> _normalized_date (1389, 11, 130)
     (1390, 3, 8)
-    >>> normalized_date (1388, 4, 32)
+    >>> _normalized_date (1388, 4, 32)
     (1388, 5, 1)
-
+    >>> _normalized_date(1391, 10, 61+365)
+    (1393, 0, 1)
+    >>> _normalized_date(1390, 10, 365+60)
+    (1391, 11, 30)
 """
 
-from pyjalali.jalali import jalali_is_jleap
+from pyjalali.jalali import jalali_is_jleap, jalali_update
+from pyjalali.types import struct_jtm
 
 days_in_month = (31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29)
 
@@ -40,58 +42,21 @@ def normalized_pair(hi, lo, factor):
     return hi, lo
 
 
-def month_days(year, mon):
-    mon %= 12
-    dim = days_in_month[mon]
-    if mon == 11 and jalali_is_jleap(year):
-        dim += 1
-    return dim
-
-
-def normalized_date(year, mon, mday):
-    # this usage should be integrated in jmktime probably
-    # TODO
-    if mon < 0 or mon > 11:
-        year, mon = normalized_pair(year, mon, 12)
-    assert 0 <= mon <= 11
-
-    dim = month_days(year, mon)
-    if mday > dim:
-        while mday > dim:
-            mday -= dim
-            mon += 1
-            dim = month_days(year, mon)
-        return normalized_date(year, mon, mday)
-    del dim
-    while mday < 1:
-        # break month to day
-        if mon == 0:
-            year -= 1
-            mon += 11
-        else:
-            mon -= 1
-        mday += month_days(year, mon)
-
-    assert 0 <= mon <= 11
-    assert 1 <= mday <= month_days(year, mon)
-    return year, mon, mday
-
-
-def normalized_date_time(year, mon, mday, hour, min, sec, ms):
+def _normalized_date(year, mon, mday):
+    """For internal testing only.  For actual normalization call jalali_update
+    or normalize_jtm.
+    0 <= mon < 12
+    1 <= mday < 32
     """
-    0 <= mon <= 11
-    1 <= mday <= 31
-    """
-    sec, ms = normalized_pair(sec, ms, 1000000)
-    min, sec = normalized_pair(min, sec, 60)
-    hour, min = normalized_pair(hour, min, 60)
-    mday, hour = normalized_pair(mday, hour, 24)
-    return normalized_date(year, mon, mday) + (hour, min, sec, ms)
+    jtm = struct_jtm()
+    jtm.tm_year = year
+    jtm.tm_mon = mon
+    jtm.tm_mday = mday
+    jalali_update(jtm)
+    return jtm.tm_year, jtm.tm_mon, jtm.tm_mday
 
 
 def normalize_jtm(jtm, microsecond=0):
-    (jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour,
-        jtm.tm_min, jtm.tm_sec, microsecond) = normalized_date_time(
-            jtm.tm_year, jtm.tm_mon, jtm.tm_mday, jtm.tm_hour,
-            jtm.tm_min, jtm.tm_sec, microsecond)
+    jtm.tm_sec, microsecond = normalized_pair(jtm.tm_sec, microsecond, 1000000)
+    jalali_update(jtm)
     return microsecond

--- a/sources/pyjalali/jalali.py
+++ b/sources/pyjalali/jalali.py
@@ -109,3 +109,9 @@ def jalali_update(jtm):
     :attr:`~.types.struct_jtm.tm_mday`.
     """
     _jalali_update(byref(jtm))
+
+_jalali_year_month_days = _libj.jalali_year_month_days
+_jalali_year_month_days.argtypes = (c_int, c_int)
+def jalali_year_month_days(year, month):
+    """Return number of days in given month of year."""
+    return _jalali_year_month_days(year, month)

--- a/sources/src/jcal.c
+++ b/sources/src/jcal.c
@@ -474,7 +474,7 @@ void show_1(struct cal_layout* l, struct jtm* j)
 
 void show_year(struct cal_layout* l, struct jtm* j)
 {
-    struct jtm _j[4];
+    struct jtm _j[4] = {{0}};
 
     char title[100];
     char buf[100];
@@ -534,7 +534,7 @@ void show_year(struct cal_layout* l, struct jtm* j)
 int main(int argc, char** argv)
 {
     struct cal_layout l;
-    struct jtm j;
+    struct jtm j = {0};
     time_t t;
 
     int opt;

--- a/test_kit/jalali_update.c
+++ b/test_kit/jalali_update.c
@@ -7,12 +7,42 @@ int main(int argc, char** argv) {
     time_t t;
     struct jtm j;
     int mday_diff = 60;
+
     time(&t);
     jlocaltime_r(&t, &j);
+    puts("Current time jtm:");
     jalali_show_time(&j);
-    printf("After %d days: \n", mday_diff);
-    j.tm_mday += mday_diff;
+    
+    char ans;
+    int* mem_ref;
+    char* mem_name;
+    do {
+        printf(">> Reset tm_year [y], tm_mon [M], tm_mday [d], tm_hour [h], tm_min [m], tm_sec[s] to: ([e] for end) ");
+        scanf("%c", &ans);
+        switch (ans) {
+            case 'y': mem_ref = &j.tm_year; mem_name = "tm_year"; break;
+            case 'M': mem_ref = &j.tm_mon; mem_name = "tm_mon"; break;
+            case 'd': mem_ref = &j.tm_mday; mem_name = "tm_mday"; break;
+            case 'h': mem_ref = &j.tm_hour; mem_name = "tm_hour"; break;
+            case 'm': mem_ref = &j.tm_min; mem_name = "tm_min"; break;
+            case 's': mem_ref = &j.tm_sec; mem_name = "tm_sec"; break;
+            case 'e': break;
+            default:
+                printf("Unrecognized field `%c'. select from [yMdhmse] and provide a value.\n", ans);
+                ans = 0;
+                break;
+        }
+        if(ans && ans != 'e') {
+            scanf("%d%*c", mem_ref);
+            printf ("%s = %d\n", mem_name, *mem_ref);
+        } else getchar();
+    } while (ans != 'e');
+
+    puts("Before update: ");
+    jalali_show_time(&j);
+
     jalali_update(&j);
+    puts("After update: ");
     jalali_show_time(&j);
     return 0;
 }

--- a/test_kit/jalali_update.c
+++ b/test_kit/jalali_update.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <time.h>
+#include <jalali/jalali.h>
+#include <jalali/jtime.h>
+
+int main(int argc, char** argv) {
+    time_t t;
+    struct jtm j;
+    int mday_diff = 60;
+    time(&t);
+    jlocaltime_r(&t, &j);
+    jalali_show_time(&j);
+    printf("After %d days: \n", mday_diff);
+    j.tm_mday += mday_diff;
+    jalali_update(&j);
+    jalali_show_time(&j);
+    return 0;
+}


### PR DESCRIPTION
The original values of tm_wday and tm_yday components of the structure must be ignored. The original values of other components are not restricted to their normal ranges and must be normalized, if need be. For example, Favardin 40 must change into Ordibehesht 9, a tm_hour of -1 means 1 hour before midnight, tm_mday of 0 means the day preceding the current month, and tm_mon of -2 means 2 months before Farvardin of tm_year.
