### PR TITLE
fix for not finding libjalali.so.0: Updating cache

### DIFF
--- a/sources/Makefile.am
+++ b/sources/Makefile.am
@@ -1,6 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS         = libjalali src man test_kit
 
+install-exec-hook:
+	@echo "make[0]: Running ldconfig ..."
+	@sudo ldconfig
+
 if WANT_PYJALALI
 install-exec-hook:
 	@echo -e "\n###########################\n"\


### PR DESCRIPTION
added ldconfig to Makefile.am to update the Cache after installation is done.  
 
// Jadi LPIC videos.
// Thank you :) 